### PR TITLE
Adds a catch-all POST endpoint.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,5 +19,6 @@ use Mix.Config
 #     config :logger, level: :info
 #
 config :origin_simulator, env: Mix.env()
+config :origin_simulator, http_port: 8080
 
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
+config :origin_simulator, http_port: 8081
 config :origin_simulator, http_client: OriginSimulator.HTTPMockClient

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -26,8 +26,6 @@ defmodule OriginSimulator do
     recipe = Recipe.parse(Plug.Conn.read_body(conn))
     Simulation.add_recipe(:simulation, recipe)
 
-    Payload.fetch(:payload, recipe)
-
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(201, Poison.encode!(Simulation.recipe(:simulation)))

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -20,7 +20,7 @@ defmodule OriginSimulator do
   end
 
   post "/add_recipe" do
-    Simulation.restart(:simulation)
+    Simulation.restart
     Process.sleep(10)
 
     recipe = Recipe.parse(Plug.Conn.read_body(conn))
@@ -33,7 +33,19 @@ defmodule OriginSimulator do
     |> send_resp(201, Poison.encode!(Simulation.recipe(:simulation)))
   end
 
-  get "/" do
+  get "/*glob" do
+    serve_payload(conn)
+  end
+
+  post "/*glob" do
+    serve_payload(conn)
+  end
+
+  match _ do
+    send_resp(conn, 404, "not found")
+  end
+
+  defp serve_payload(conn) do
     {status, latency} = Simulation.state(:simulation)
 
     if latency > 0 do
@@ -45,9 +57,5 @@ defmodule OriginSimulator do
     conn
     |> put_resp_content_type("text/html")
     |> send_resp(status, body)
-  end
-
-  match _ do
-    send_resp(conn, 404, "not found")
   end
 end

--- a/lib/origin_simulator/application.ex
+++ b/lib/origin_simulator/application.ex
@@ -15,7 +15,7 @@ defmodule OriginSimulator.Application do
       #:hackney_pool.child_spec(:origin_pool, [timeout: 10_000, max_connections: 8000]),
     ]
 
-    opts = [strategy: :one_for_one, name: OriginSimulator.Supervisor]
+    opts = [strategy: :one_for_one, name: OriginSimulator.Supervisor, max_restarts: 30]
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/origin_simulator/application.ex
+++ b/lib/origin_simulator/application.ex
@@ -8,13 +8,21 @@ defmodule OriginSimulator.Application do
       Plug.Adapters.Cowboy.child_spec(
         scheme: :http,
         plug: OriginSimulator,
-        options: [port: Application.fetch_env!(:origin_simulator, :http_port), protocol_options: [max_keepalive: 5_000_000]]
+        options: [
+          port: Application.fetch_env!(:origin_simulator, :http_port),
+          protocol_options: [max_keepalive: 5_000_000]
+        ]
       ),
       OriginSimulator.Simulation,
       OriginSimulator.Payload
     ]
 
-    opts = [strategy: :one_for_one, name: OriginSimulator.Supervisor, max_restarts: 30]
+    opts = [
+      strategy: :one_for_all,
+      name: OriginSimulator.Supervisor,
+      max_restarts: 30
+    ]
+
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/origin_simulator/application.ex
+++ b/lib/origin_simulator/application.ex
@@ -12,7 +12,6 @@ defmodule OriginSimulator.Application do
       ),
       OriginSimulator.Simulation,
       OriginSimulator.Payload
-      #:hackney_pool.child_spec(:origin_pool, [timeout: 10_000, max_connections: 8000]),
     ]
 
     opts = [strategy: :one_for_one, name: OriginSimulator.Supervisor, max_restarts: 30]

--- a/lib/origin_simulator/application.ex
+++ b/lib/origin_simulator/application.ex
@@ -8,7 +8,7 @@ defmodule OriginSimulator.Application do
       Plug.Adapters.Cowboy.child_spec(
         scheme: :http,
         plug: OriginSimulator,
-        options: [port: 8080, protocol_options: [max_keepalive: 5_000_000]]
+        options: [port: Application.fetch_env!(:origin_simulator, :http_port), protocol_options: [max_keepalive: 5_000_000]]
       ),
       OriginSimulator.Simulation,
       OriginSimulator.Payload

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -2,6 +2,7 @@ defmodule OriginSimulator.Payload do
   use GenServer
 
   alias OriginSimulator.Recipe
+
   ## Client API
 
   def start_link(opts) do

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -1,6 +1,8 @@
 defmodule OriginSimulator.Simulation do
   use GenServer
 
+  alias OriginSimulator.Payload
+
   ## Client API
 
   def start_link(opts) do
@@ -43,6 +45,8 @@ defmodule OriginSimulator.Simulation do
 
   @impl true
   def handle_call({:add_recipe, new_recipe}, _caller, state) do
+    Payload.fetch(:payload, new_recipe)
+
     Enum.map(new_recipe.stages, fn item ->
       Process.send_after(self(), {:update, item["status"], item["latency"]}, item["at"])
     end)

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -19,12 +19,9 @@ defmodule OriginSimulator.Simulation do
     GenServer.call(server, {:add_recipe, new_recipe})
   end
 
-  def restart(server) do
-    server_pid = GenServer.whereis(server)
-
-    if server_pid do
-      Process.exit(server_pid, :kill)
-    end
+  def restart do
+    GenServer.stop(:simulation)
+    GenServer.stop(:payload)
   end
 
   ## Server Callbacks

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -23,7 +23,6 @@ defmodule OriginSimulator.Simulation do
 
   def restart do
     GenServer.stop(:simulation)
-    GenServer.stop(:payload)
   end
 
   ## Server Callbacks

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -1,5 +1,93 @@
 defmodule OriginSimulatorTest do
   use ExUnit.Case
+  use Plug.Test
+
   doctest OriginSimulator
 
+  setup do
+    OriginSimulator.Simulation.restart()
+    Process.sleep(10)
+  end
+
+  describe "GET /status" do
+    test "will return 'OK'" do
+      conn = conn(:get, "/status") |> OriginSimulator.call([])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+      assert conn.resp_body == "ok!"
+    end
+  end
+
+  describe "GET /current_recipe" do
+    test "will return an error message if payload has not been set" do
+      conn = conn(:get, "/current_recipe") |> OriginSimulator.call([])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert conn.resp_body ==  "\"Not set, please POST a recipe to /add_recipe\""
+    end
+
+    test "will return the payload if set" do
+      payload = %{
+        "origin" => "https://www.bbc.co.uk/news",
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => 100}],
+        "random" => nil
+      }
+
+      conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
+
+      conn = conn(:get, "/current_recipe")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert Poison.decode!(conn.resp_body) == payload
+    end
+  end
+
+  describe "GET page" do
+    test "will return the origin page" do
+      payload = %{
+        "origin" => "https://www.bbc.co.uk/news",
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
+      }
+
+      conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
+
+      Process.sleep 20
+
+      conn = conn(:get, "/")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+      assert conn.resp_body == "some content from origin"
+    end
+  end
+
+  describe "POST page" do
+    test "will return the simulated page" do
+      payload = %{
+        "origin" => "https://www.bbc.co.uk/news",
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
+      }
+
+      conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
+
+      Process.sleep 20
+
+      conn = conn(:post, "/", "")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+      assert conn.resp_body == "some content from origin"
+    end
+  end
 end

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -25,8 +25,8 @@ defmodule OriginSimulator.SimulationTest do
 
   describe "with no recipe loaded" do
     setup do
-      Simulation.restart(:simulation)
-      Process.sleep(100)
+      Simulation.restart()
+      Process.sleep(10)
     end
 
     test "state() returns a tuple with default values" do


### PR DESCRIPTION
This allows OriginSimulator to handle `POST` requests exactly as it does for standard `GET`s.
A use case for this is to simulate an AWS Lambda invocation, which the SDK internally transforms to an HTTP POST.  

In this scenario, we want to load test a service which would call a Lambda trough direct SDK invocation, we can hijack the POST request to point to OriginSimulator and generate a specific latency.