### PR TITLE
Handle content in recipe

### DIFF
--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -53,7 +53,15 @@ defmodule OriginSimulator do
     {:ok, body} = Payload.body(:payload, status)
 
     conn
-    |> put_resp_content_type("text/html")
+    |> put_resp_content_type(content_type(body))
     |> send_resp(status, body)
+  end
+
+  defp content_type(body) do
+    if String.first(body) == "{" do
+      "application/json"
+    else
+      "text/html"
+    end
   end
 end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -13,6 +13,10 @@ defmodule OriginSimulator.Payload do
     GenServer.call(server, {:fetch, value})
   end
 
+  def fetch(server, %Recipe{body: value}) when is_binary(value) do
+    GenServer.call(server, {:parse, value})
+  end
+
   def fetch(server, %Recipe{random: value}) when is_number(value) do
     GenServer.call(server, {:generate, value})
   end
@@ -46,6 +50,13 @@ defmodule OriginSimulator.Payload do
     env = Application.get_env(:origin_simulator, :env)
 
     {:ok, %HTTPoison.Response{body: body}} = OriginSimulator.HTTPClient.get(origin, env)
+    :ets.insert(:payload, {"body", body})
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:parse, body}, _from, state) do
     :ets.insert(:payload, {"body", body})
 
     {:reply, :ok, state}

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,6 +1,6 @@
 defmodule OriginSimulator.Recipe do
-  defstruct origin: nil, random: nil, stages: []
-  @type t :: %__MODULE__{origin: String.t(), random: non_neg_integer}
+  defstruct origin: nil, body: nil, random: nil, stages: []
+  @type t :: %__MODULE__{origin: String.t(), body: String.t(), random: non_neg_integer}
 
   @spec parse({:ok, binary(), any()}) :: binary()
   def parse({:ok, body, _conn}) do

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -3,23 +3,47 @@ defmodule OriginSimulator.PayloadTest do
 
   alias OriginSimulator.Recipe
 
-  setup do
-    OriginSimulator.Payload.fetch(:payload, %Recipe{origin: "https://www.bbc.co.uk"})
+  describe "with origin" do
+    setup do
+      OriginSimulator.Payload.fetch(:payload, %Recipe{origin: "https://www.bbc.co.uk"})
+    end
+
+    test "Always return an error body for 5xx" do
+      assert OriginSimulator.Payload.body(:payload, 500) == {:ok, "Error 500"}
+    end
+
+    test "Always return 'Not Found' for 404s" do
+      assert OriginSimulator.Payload.body(:payload, 404) == {:ok, "Not found"}
+    end
+
+    test "Suggests to add a recipe for 406" do
+      assert OriginSimulator.Payload.body(:payload, 406) == {:ok, "Recipe not set, please POST a recipe to /add_recipe"}
+    end
+
+    test "returns the origin body for 200" do
+      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "some content from origin"}
+    end
   end
 
-  test "Always return an error body for 5xx" do
-    assert OriginSimulator.Payload.body(:payload, 500) == {:ok, "Error 500"}
-  end
+  describe "with content" do
+    setup do
+      OriginSimulator.Payload.fetch(:payload, %Recipe{body: "{\"hello\":\"world\"}"})
+    end
 
-  test "Always return 'Not Found' for 404s" do
-    assert OriginSimulator.Payload.body(:payload, 404) == {:ok, "Not found"}
-  end
+    test "Always return an error body for 5xx" do
+      assert OriginSimulator.Payload.body(:payload, 500) == {:ok, "Error 500"}
+    end
 
-  test "Suggests to add a recipe for 406" do
-    assert OriginSimulator.Payload.body(:payload, 406) == {:ok, "Recipe not set, please POST a recipe to /add_recipe"}
-  end
+    test "Always return 'Not Found' for 404s" do
+      assert OriginSimulator.Payload.body(:payload, 404) == {:ok, "Not found"}
+    end
 
-  test "returns the origin body for 200" do
-    assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "some content from origin"}
+    test "Suggests to add a recipe for 406" do
+      assert OriginSimulator.Payload.body(:payload, 406) == {:ok, "Recipe not set, please POST a recipe to /add_recipe"}
+    end
+
+    test "returns the origin body for 200" do
+      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "{\"hello\":\"world\"}"}
+    end
   end
 end


### PR DESCRIPTION
## Problem

Currently the origin simulator only allows content to be fetched from an origin.

## Solution

This PR allows a payload body to be specified directly.