### PR TITLE
Adds a supervision tree.

### DIFF
--- a/lib/origin_simulator/application.ex
+++ b/lib/origin_simulator/application.ex
@@ -13,13 +13,12 @@ defmodule OriginSimulator.Application do
           protocol_options: [max_keepalive: 5_000_000]
         ]
       ),
-      OriginSimulator.Simulation,
-      OriginSimulator.Payload
+      OriginSimulator.Supervisor
     ]
 
     opts = [
-      strategy: :one_for_all,
-      name: OriginSimulator.Supervisor,
+      strategy: :one_for_one,
+      name: OriginSimulator.AppSupervisor,
       max_restarts: 30
     ]
 

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule OriginSimulator.Supervisor do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      OriginSimulator.Simulation,
+      OriginSimulator.Payload
+    ]
+
+    opts = [
+      strategy: :one_for_all,
+      max_restarts: 30
+    ]
+    Supervisor.init(children, opts)
+  end
+end


### PR DESCRIPTION
The new approach uses a supervisor tree where the Application starts Cowboy and
a Supervisor with a `:one_for_one` strategy. The supervisor instead uses a
`:one_for_all` strategy so that at any restart of either Payload or Simulation
both the GenServers are restarted.

Previously any single killed process would restart Cowboy as well, which wasn't a
good idea..


<img width="511" alt="supervision_tree" src="https://user-images.githubusercontent.com/3269/53587920-88991880-3b83-11e9-9410-0161e7b20102.png">
