### PR TITLE
Range latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Where `at` represents the time points (in milliseconds) for a state mutation, an
        HTTP 404 50ms           HTTP 503 2s       HTTP 200 100ms
 ```
 
+## Latency
+
+Any stage defines the simulated latency in ms. Is possible to simulate random latency using an array of values. 
+In the example below any response will take a random amount of time within the range 1000..1500:
+
+```json
+{
+    "random": 428,
+    "stages": [
+        {
+            "at": 0,
+            "latency": [1000, 1500],
+            "status": 200
+        }
+    ]
+}
+```
+
+
 ## Sources
 
 OriginSimulator can be used in three ways.

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -46,9 +46,7 @@ defmodule OriginSimulator do
   defp serve_payload(conn) do
     {status, latency} = Simulation.state(:simulation)
 
-    if latency > 0 do
-      :timer.sleep(latency)
-    end
+    sleep(latency)
 
     {:ok, body} = Payload.body(:payload, status)
 
@@ -63,5 +61,15 @@ defmodule OriginSimulator do
     else
       "text/html"
     end
+  end
+
+  defp sleep(0), do: nil
+
+  defp sleep(time) when is_integer(time) do
+    :timer.sleep(time)
+  end
+
+  defp sleep(%Range{} = time) do
+    :timer.sleep(Enum.random(time))
   end
 end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -47,7 +47,7 @@ defmodule OriginSimulator.Simulation do
     Payload.fetch(:payload, new_recipe)
 
     Enum.map(new_recipe.stages, fn item ->
-      Process.send_after(self(), {:update, item["status"], item["latency"]}, item["at"])
+      Process.send_after(self(), {:update, item["status"], parse_latency(item["latency"])}, item["at"])
     end)
 
     {:reply, :ok, %{state | recipe: new_recipe }}
@@ -57,5 +57,11 @@ defmodule OriginSimulator.Simulation do
   def handle_info({:update, status, latency}, state) do
     new_state = Map.merge(state, %{status: status, latency: latency})
     {:noreply, new_state}
+  end
+
+  defp parse_latency(latency) when is_integer(latency), do: latency
+
+  defp parse_latency(latency) when is_list(latency) do
+    apply(Range, :new, latency)
   end
 end

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -92,6 +92,27 @@ defmodule OriginSimulatorTest do
     end
   end
 
+  describe "GET page with random latency within range" do
+    test "will return the origin page" do
+      payload = %{
+        "body" =>   "{\"hello\":\"world\"}",
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => [10, 50]}]
+      }
+
+      conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
+
+      Process.sleep 20
+
+      conn = conn(:get, "/")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert conn.resp_body == "{\"hello\":\"world\"}"
+    end
+  end
+
   describe "POST page with origin" do
     test "will return the simulated page" do
       payload = %{

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -8,10 +8,15 @@ defmodule OriginSimulator.SimulationTest do
                             stages: [%{"at" => 0, "status" => 200, "latency" => 1000}]}
   end
 
+  def test_range_recipe() do
+    %OriginSimulator.Recipe{origin: "foo",
+                            stages: [%{"at" => 0, "status" => 200, "latency" => [1000, 1200]}]}
+  end
+
   describe "with loaded recipe" do
     setup do
       Simulation.add_recipe(:simulation, test_recipe())
-      Process.sleep(10)
+      Process.sleep(5)
     end
 
     test "state() returns a tuple with http status and latency in ms" do
@@ -23,10 +28,25 @@ defmodule OriginSimulator.SimulationTest do
     end
   end
 
+  describe "with a recipe containing a range" do
+    setup do
+      Simulation.add_recipe(:simulation, test_range_recipe())
+      Process.sleep(5)
+    end
+
+    test "state() returns a tuple with http status and latency in ms" do
+      assert Simulation.state(:simulation) == {200, 1000..1200}
+    end
+
+    test "recipe() returns the loaded recipe" do
+      assert Simulation.recipe(:simulation) == test_range_recipe()
+    end
+  end
+
   describe "with no recipe loaded" do
     setup do
       Simulation.restart()
-      Process.sleep(10)
+      Process.sleep(5)
     end
 
     test "state() returns a tuple with default values" do


### PR DESCRIPTION
Adds the option to define random latency within a range.

```json
{
    "random": 428,
    "stages": [
        {
            "at": 0,
            "latency": [100, 500],
            "status": 200
        }
    ]
}
```
