### PR TITLE
Nominal duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ A JSON recipe defines the different stages of the scenario. This is an example o
     "stages": [
         {
             "at": 0,
-            "latency": 50,
+            "latency": "50ms",
             "status": 404
         },
         {
             "at": 4000,
-            "latency": 2000,
+            "latency": "2s",
             "status": 503
         },
         {
             "at": 6000,
-            "latency": 100,
+            "latency": "100ms"",
             "status": 200
         }
     ]
@@ -69,7 +69,7 @@ In the example below any response will take a random amount of time within the r
     "stages": [
         {
             "at": 0,
-            "latency": [1000, 1500],
+            "latency": "1000ms..1500ms",
             "status": 200
         }
     ]
@@ -89,7 +89,7 @@ OriginSimulator can be used in three ways.
     "stages": [
         {
             "at": 0,
-            "latency": 100,
+            "latency": "100ms",
             "status": 200
         }
     ]
@@ -106,7 +106,7 @@ In this example we are requiring a continuous successful response with no simula
     "stages": [
         {
             "at": 0,
-            "latency": 100,
+            "latency": "100ms",
             "status": 200
         }
     ]
@@ -161,9 +161,9 @@ $ cat examples/sample_recipe.json
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0,    "status": 404, "latency": 50},
-        { "at": 4000, "status": 503, "latency": 2000},
-        { "at": 9000, "status": 200, "latency": 100}
+        { "at": 0,    "status": 404, "latency": "50ms"},
+        { "at": 4000, "status": 503, "latency": "2s"},
+        { "at": 9000, "status": 200, "latency": "100ms"}
     ]
 }
 
@@ -206,7 +206,7 @@ recipe:
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 200, "latency": 0}
+        { "at": 0, "status": 200, "latency": "0ms"}
     ]
 }
 ```
@@ -231,7 +231,7 @@ recipe:
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 200, "latency": 100}
+        { "at": 0, "status": 200, "latency": "100ms"}
     ]
 }
 ```
@@ -260,7 +260,7 @@ recipe
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 200, "latency": 1000}
+        { "at": 0, "status": 200, "latency": "1s"}
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A JSON recipe defines the different stages of the scenario. This is an example o
         },
         {
             "at": 6000,
-            "latency": "100ms"",
+            "latency": "100ms",
             "status": 200
         }
     ]
@@ -123,7 +123,7 @@ In this example content is posted along with the recipe. Where the payload body 
     "stages": [
         {
             "at": 0,
-            "latency": 100,
+            "latency": "100ms",
             "status": 200
         }
     ]

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ A JSON recipe defines the different stages of the scenario. This is an example o
             "status": 404
         },
         {
-            "at": 4000,
+            "at": "4s",
             "latency": "2s",
             "status": 503
         },
         {
-            "at": 6000,
+            "at": "6s",
             "latency": "100ms",
             "status": 200
         }
@@ -162,8 +162,8 @@ $ cat examples/sample_recipe.json
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
         { "at": 0,    "status": 404, "latency": "50ms"},
-        { "at": 4000, "status": 503, "latency": "2s"},
-        { "at": 9000, "status": 200, "latency": "100ms"}
+        { "at": "4s", "status": 503, "latency": "2s"},
+        { "at": "9s", "status": 200, "latency": "100ms"}
     ]
 }
 

--- a/examples/failure_scenario.json
+++ b/examples/failure_scenario.json
@@ -1,0 +1,7 @@
+{
+    "origin": "https://www.bbc.co.uk/news",
+    "stages": [
+        { "at": "0s", "status": 200, "latency": "100ms"},
+        { "at": "6s", "status": 504, "latency": "1s"}
+    ]
+}

--- a/examples/permanent_200_100ms_latency.json
+++ b/examples/permanent_200_100ms_latency.json
@@ -1,6 +1,6 @@
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 200, "latency": 100}
+        { "at": 0, "status": 200, "latency": "100ms"}
     ]
 }

--- a/examples/permanent_200_2s_latency.json
+++ b/examples/permanent_200_2s_latency.json
@@ -1,6 +1,6 @@
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 200, "latency": 2000}
+        { "at": 0, "status": 200, "latency": "2s"}
     ]
 }

--- a/examples/permanent_200_random_200kn_range100_200ms.json
+++ b/examples/permanent_200_random_200kn_range100_200ms.json
@@ -1,0 +1,6 @@
+{
+    "random": 100,
+    "stages": [
+        { "at": 0, "status": 200, "latency": "100ms..200ms"}
+    ]
+}

--- a/examples/permanent_504.json
+++ b/examples/permanent_504.json
@@ -1,6 +1,6 @@
 {
     "origin": "https://www.bbc.co.uk/news",
     "stages": [
-        { "at": 0, "status": 504, "latency": 1000}
+        { "at": 0, "status": 504, "latency": "1s"}
     ]
 }

--- a/examples/sample_recipe.json
+++ b/examples/sample_recipe.json
@@ -1,8 +1,0 @@
-{
-    "origin": "https://www.bbc.co.uk/news",
-    "stages": [
-        { "at": 0,    "status": 404, "latency": 50},
-        { "at": 4000, "status": 503, "latency": 2000},
-        { "at": 9000, "status": 200, "latency": 100}
-    ]
-}

--- a/examples/stable.txt
+++ b/examples/stable.txt
@@ -1,6 +1,0 @@
-http:///www.bbc.co.uk/news
-----
-duration, status, latency
-1m,       200,    100ms
-2m,       503,    200ms
-*,        200,     50ms

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -63,13 +63,7 @@ defmodule OriginSimulator do
     end
   end
 
-  defp sleep([0]), do: nil
-
-  defp sleep([time]), do: :timer.sleep(time)
-
-  defp sleep(times) when is_list(times) do
-    apply(Range, :new, times)
-    |> Enum.random
-    |> :timer.sleep()
-  end
+  defp sleep(nil), do: nil
+  defp sleep(%Range{} = time), do: :timer.sleep(Enum.random(time))
+  defp sleep(duration), do: :timer.sleep(duration)
 end

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -63,7 +63,7 @@ defmodule OriginSimulator do
     end
   end
 
-  defp sleep(nil), do: nil
+  defp sleep(0), do: nil
   defp sleep(%Range{} = time), do: :timer.sleep(Enum.random(time))
   defp sleep(duration), do: :timer.sleep(duration)
 end

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -63,13 +63,13 @@ defmodule OriginSimulator do
     end
   end
 
-  defp sleep(0), do: nil
+  defp sleep([0]), do: nil
 
-  defp sleep(time) when is_integer(time) do
-    :timer.sleep(time)
-  end
+  defp sleep([time]), do: :timer.sleep(time)
 
-  defp sleep(%Range{} = time) do
-    :timer.sleep(Enum.random(time))
+  defp sleep(times) when is_list(times) do
+    apply(Range, :new, times)
+    |> Enum.random
+    |> :timer.sleep()
   end
 end

--- a/lib/origin_simulator/duration.ex
+++ b/lib/origin_simulator/duration.ex
@@ -1,5 +1,5 @@
 defmodule OriginSimulator.Duration do
-  def parse(0), do:  nil
+  def parse(0), do: 0
 
   def parse(time) when is_integer(time), do: raise("Invalid stage latency, please use time in s or ms")
 
@@ -15,7 +15,7 @@ defmodule OriginSimulator.Duration do
 
   def parse({time, "s"}), do: time * 1000
 
-  def parse({0, _}), do: nil
+  def parse({0, _}), do: 0
 
   def parse(times) when is_list(times) do
     min_max = Enum.map(times, fn (t) -> parse(t) end)

--- a/lib/origin_simulator/duration.ex
+++ b/lib/origin_simulator/duration.ex
@@ -2,7 +2,7 @@ defmodule OriginSimulator.Duration do
   def parse(0), do: 0
 
   def parse(time) when is_integer(time) do
-    raise("Invalid stage latency, please define time in s or ms")
+    raise("Invalid timing, please define time in s or ms")
   end
 
   def parse(time) when is_binary(time) do
@@ -19,8 +19,11 @@ defmodule OriginSimulator.Duration do
 
   def parse({0, _}), do: 0
 
-  def parse(times) when is_list(times) do
-    min_max = Enum.map(times, fn (t) -> parse(t) end)
-    apply(Range, :new, min_max)
+  def parse({_, _}) do
+    raise("Invalid timing, please define time in s or ms")
+  end
+
+  def parse([min, max]) do
+    Range.new(parse(min), parse(max))
   end
 end

--- a/lib/origin_simulator/duration.ex
+++ b/lib/origin_simulator/duration.ex
@@ -1,7 +1,9 @@
 defmodule OriginSimulator.Duration do
   def parse(0), do: 0
 
-  def parse(time) when is_integer(time), do: raise("Invalid stage latency, please use time in s or ms")
+  def parse(time) when is_integer(time) do
+    raise("Invalid stage latency, please define time in s or ms")
+  end
 
   def parse(time) when is_binary(time) do
     cond do

--- a/lib/origin_simulator/duration.ex
+++ b/lib/origin_simulator/duration.ex
@@ -1,0 +1,24 @@
+defmodule OriginSimulator.Duration do
+  def parse(0), do:  nil
+
+  def parse(time) when is_integer(time), do: raise("Invalid stage latency, please use time in s or ms")
+
+  def parse(time) when is_binary(time) do
+    cond do
+      String.contains?(time, "..") -> String.split(time, "..")
+      true -> Integer.parse(time)
+    end
+    |> parse()
+  end
+
+  def parse({time, "ms"}), do: time
+
+  def parse({time, "s"}), do: time * 1000
+
+  def parse({0, _}), do: nil
+
+  def parse(times) when is_list(times) do
+    min_max = Enum.map(times, fn (t) -> parse(t) end)
+    apply(Range, :new, min_max)
+  end
+end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -1,7 +1,7 @@
 defmodule OriginSimulator.Simulation do
   use GenServer
 
-  alias OriginSimulator.Payload
+  alias OriginSimulator.{Payload,Duration}
 
   ## Client API
 
@@ -47,7 +47,7 @@ defmodule OriginSimulator.Simulation do
     Payload.fetch(:payload, new_recipe)
 
     Enum.map(new_recipe.stages, fn item ->
-      Process.send_after(self(), {:update, item["status"], parse_latency(item["latency"])}, item["at"])
+      Process.send_after(self(), {:update, item["status"], Duration.parse(item["latency"])}, item["at"])
     end)
 
     {:reply, :ok, %{state | recipe: new_recipe }}
@@ -58,17 +58,4 @@ defmodule OriginSimulator.Simulation do
     new_state = Map.merge(state, %{status: status, latency: latency})
     {:noreply, new_state}
   end
-
-  defp parse_latency(latency) when is_binary(latency) do
-    String.split(latency, "..")
-    |> Enum.map(fn d -> process_duration(Integer.parse(d)) end)
-  end
-
-  defp parse_latency(latency) when is_integer(latency) do
-    Integer.to_string(latency) |> parse_latency()
-  end
-
-  defp process_duration({duration, "ms"}), do: duration
-  defp process_duration({duration, "s"}), do: duration * 1000
-  defp process_duration({duration, ""}), do: duration
 end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -59,9 +59,16 @@ defmodule OriginSimulator.Simulation do
     {:noreply, new_state}
   end
 
-  defp parse_latency(latency) when is_integer(latency), do: latency
-
-  defp parse_latency(latency) when is_list(latency) do
-    apply(Range, :new, latency)
+  defp parse_latency(latency) when is_binary(latency) do
+    String.split(latency, "..")
+    |> Enum.map(fn d -> process_duration(Integer.parse(d)) end)
   end
+
+  defp parse_latency(latency) when is_integer(latency) do
+    Integer.to_string(latency) |> parse_latency()
+  end
+
+  defp process_duration({duration, "ms"}), do: duration
+  defp process_duration({duration, "s"}), do: duration * 1000
+  defp process_duration({duration, ""}), do: duration
 end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -47,7 +47,9 @@ defmodule OriginSimulator.Simulation do
     Payload.fetch(:payload, new_recipe)
 
     Enum.map(new_recipe.stages, fn item ->
-      Process.send_after(self(), {:update, item["status"], Duration.parse(item["latency"])}, Duration.parse(item["at"]))
+      Process.send_after(self(),
+        {:update, item["status"], Duration.parse(item["latency"])},
+        Duration.parse(item["at"]))
     end)
 
     {:reply, :ok, %{state | recipe: new_recipe }}

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -47,7 +47,7 @@ defmodule OriginSimulator.Simulation do
     Payload.fetch(:payload, new_recipe)
 
     Enum.map(new_recipe.stages, fn item ->
-      Process.send_after(self(), {:update, item["status"], Duration.parse(item["latency"])}, item["at"])
+      Process.send_after(self(), {:update, item["status"], Duration.parse(item["latency"])}, Duration.parse(item["at"]))
     end)
 
     {:reply, :ok, %{state | recipe: new_recipe }}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OriginSimulator.MixProject do
   def project do
     [
       app: :origin_simulator,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/origin_simulator/duration_test.exs
+++ b/test/origin_simulator/duration_test.exs
@@ -9,7 +9,7 @@ defmodule OriginSimulator.DurationTest do
     end
 
     test "1" do
-      assert_raise RuntimeError, "Invalid stage latency, please define time in s or ms", fn () -> Duration.parse(1) end
+      assert_raise RuntimeError, "Invalid timing, please define time in s or ms", fn () -> Duration.parse(1) end
     end
   end
 
@@ -30,7 +30,7 @@ defmodule OriginSimulator.DurationTest do
       assert Duration.parse("100ms") == 100
     end
 
-    test "1ms" do
+    test "1s" do
       assert Duration.parse("1s") == 1000
     end
 
@@ -45,10 +45,14 @@ defmodule OriginSimulator.DurationTest do
     test "range 800ms..1s" do
       assert Duration.parse("800ms..1s") == 800..1000
     end
+
+    test "invalid range" do
+      assert_raise RuntimeError, "Invalid timing, please define time in s or ms", fn () -> Duration.parse("1..2s") end
+    end
   end
 
   describe "parsing a tuple" do
-    test "0" do
+    test 0 do
       assert Duration.parse({0, ""}) == 0
     end
 
@@ -64,7 +68,7 @@ defmodule OriginSimulator.DurationTest do
       assert Duration.parse({100, "ms"}) == 100
     end
 
-    test "1ms" do
+    test "1s" do
       assert Duration.parse({1, "s"}) == 1000
     end
   end

--- a/test/origin_simulator/duration_test.exs
+++ b/test/origin_simulator/duration_test.exs
@@ -7,6 +7,10 @@ defmodule OriginSimulator.DurationTest do
     test "0" do
       assert Duration.parse(0) == nil
     end
+
+    test "1" do
+      assert_raise RuntimeError, "Invalid stage latency, please use time in s or ms", fn -> Duration.parse(1) end
+    end
   end
 
   describe "parsing a binary string" do

--- a/test/origin_simulator/duration_test.exs
+++ b/test/origin_simulator/duration_test.exs
@@ -9,7 +9,7 @@ defmodule OriginSimulator.DurationTest do
     end
 
     test "1" do
-      assert_raise RuntimeError, "Invalid stage latency, please use time in s or ms", fn -> Duration.parse(1) end
+      assert_raise RuntimeError, "Invalid stage latency, please define time in s or ms", fn () -> Duration.parse(1) end
     end
   end
 

--- a/test/origin_simulator/duration_test.exs
+++ b/test/origin_simulator/duration_test.exs
@@ -5,7 +5,7 @@ defmodule OriginSimulator.DurationTest do
 
   describe "parsing a integer" do
     test "0" do
-      assert Duration.parse(0) == nil
+      assert Duration.parse(0) == 0
     end
 
     test "1" do
@@ -15,7 +15,7 @@ defmodule OriginSimulator.DurationTest do
 
   describe "parsing a binary string" do
     test "0" do
-      assert Duration.parse("0") == nil
+      assert Duration.parse("0") == 0
     end
 
     test "0ms" do
@@ -49,7 +49,7 @@ defmodule OriginSimulator.DurationTest do
 
   describe "parsing a tuple" do
     test "0" do
-      assert Duration.parse({0, ""}) == nil
+      assert Duration.parse({0, ""}) == 0
     end
 
     test "0ms" do

--- a/test/origin_simulator/duration_test.exs
+++ b/test/origin_simulator/duration_test.exs
@@ -1,0 +1,81 @@
+defmodule OriginSimulator.DurationTest do
+  use ExUnit.Case
+
+  alias OriginSimulator.Duration
+
+  describe "parsing a integer" do
+    test "0" do
+      assert Duration.parse(0) == nil
+    end
+  end
+
+  describe "parsing a binary string" do
+    test "0" do
+      assert Duration.parse("0") == nil
+    end
+
+    test "0ms" do
+      assert Duration.parse("0ms") == 0
+    end
+
+    test "0s" do
+      assert Duration.parse("0s") == 0
+    end
+
+    test "100ms" do
+      assert Duration.parse("100ms") == 100
+    end
+
+    test "1ms" do
+      assert Duration.parse("1s") == 1000
+    end
+
+    test "range 100ms..200ms" do
+      assert Duration.parse("100ms..200ms") == 100..200
+    end
+
+    test "range 1s..2s" do
+      assert Duration.parse("1s..2s") == 1000..2000
+    end
+
+    test "range 800ms..1s" do
+      assert Duration.parse("800ms..1s") == 800..1000
+    end
+  end
+
+  describe "parsing a tuple" do
+    test "0" do
+      assert Duration.parse({0, ""}) == nil
+    end
+
+    test "0ms" do
+      assert Duration.parse({0, "ms"}) == 0
+    end
+
+    test "0s" do
+      assert Duration.parse({0, "s"}) == 0
+    end
+
+    test "100ms" do
+      assert Duration.parse({100, "ms"}) == 100
+    end
+
+    test "1ms" do
+      assert Duration.parse({1, "s"}) == 1000
+    end
+  end
+
+  describe "parsing an array of tuples" do
+    test "range 100ms..200ms" do
+      assert Duration.parse([{100, "ms"}, {200, "ms"}]) == 100..200
+    end
+
+    test "range 1s..2s" do
+      assert Duration.parse([{1, "s"}, {2, "s"}]) == 1000..2000
+    end
+
+    test "range 800ms..1s" do
+      assert Duration.parse([{800, "ms"}, {1, "s"}]) == 800..1000
+    end
+  end
+end

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -96,7 +96,7 @@ defmodule OriginSimulatorTest do
     test "will return the origin page" do
       payload = %{
         "body" =>   "{\"hello\":\"world\"}",
-        "stages" => [%{ "at" => 0, "status" => 200, "latency" => [10, 50]}]
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => "10ms..50ms"}]
       }
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -33,7 +33,26 @@ defmodule OriginSimulatorTest do
     test "will return the payload if set" do
       payload = %{
         "origin" => "https://www.bbc.co.uk/news",
-        "stages" => [%{ "at" => 0, "status" => 200, "latency" => 100}],
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms"}],
+        "random" => nil,
+        "body"   => nil
+      }
+
+      conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
+
+      conn = conn(:get, "/current_recipe")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert Poison.decode!(conn.resp_body) == payload
+    end
+
+    test "will return the payload if set for ranged latencies" do
+      payload = %{
+        "origin" => "https://www.bbc.co.uk/news",
+        "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms..200ms"}],
         "random" => nil,
         "body"   => nil
       }

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -13,6 +13,12 @@ defmodule OriginSimulator.SimulationTest do
                             stages: [%{"at" => 0, "status" => 200, "latency" => "1s..1200ms"}]}
   end
 
+  def test_recipe_with_multiple_stages() do
+    %OriginSimulator.Recipe{origin: "foo",
+                            stages: [%{"at" => 0, "status" => 200, "latency" => "0s"},
+                                     %{"at" => "60ms", "status" => 503, "latency" => "1s"}]}
+  end
+
   describe "with loaded recipe" do
     setup do
       Simulation.add_recipe(:simulation, test_recipe())
@@ -40,6 +46,23 @@ defmodule OriginSimulator.SimulationTest do
 
     test "recipe() returns the loaded recipe" do
       assert Simulation.recipe(:simulation) == test_range_recipe()
+    end
+  end
+
+  describe "with a recipe containing multiple stages" do
+    setup do
+      Simulation.add_recipe(:simulation, test_recipe_with_multiple_stages())
+      Process.sleep(5)
+    end
+
+    test "state() returns a tuple with http status and latency in ms" do
+      assert Simulation.state(:simulation) == {200, 0}
+      Process.sleep(80)
+      assert Simulation.state(:simulation) == {503, 1000}
+    end
+
+    test "recipe() returns the loaded recipe" do
+      assert Simulation.recipe(:simulation) == test_recipe_with_multiple_stages()
     end
   end
 

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -5,7 +5,7 @@ defmodule OriginSimulator.SimulationTest do
 
   def test_recipe() do
     %OriginSimulator.Recipe{origin: "foo",
-                            stages: [%{"at" => 0, "status" => 200, "latency" => 1000}]}
+                            stages: [%{"at" => 0, "status" => 200, "latency" => "1s"}]}
   end
 
   def test_range_recipe() do
@@ -20,7 +20,7 @@ defmodule OriginSimulator.SimulationTest do
     end
 
     test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, [1000]}
+      assert Simulation.state(:simulation) == {200, 1000}
     end
 
     test "recipe() returns the loaded recipe" do
@@ -35,7 +35,7 @@ defmodule OriginSimulator.SimulationTest do
     end
 
     test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, [1000,1200]}
+      assert Simulation.state(:simulation) == {200, 1000..1200}
     end
 
     test "recipe() returns the loaded recipe" do

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -10,7 +10,7 @@ defmodule OriginSimulator.SimulationTest do
 
   def test_range_recipe() do
     %OriginSimulator.Recipe{origin: "foo",
-                            stages: [%{"at" => 0, "status" => 200, "latency" => [1000, 1200]}]}
+                            stages: [%{"at" => 0, "status" => 200, "latency" => "1s..1200ms"}]}
   end
 
   describe "with loaded recipe" do
@@ -20,7 +20,7 @@ defmodule OriginSimulator.SimulationTest do
     end
 
     test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, 1000}
+      assert Simulation.state(:simulation) == {200, [1000]}
     end
 
     test "recipe() returns the loaded recipe" do
@@ -35,7 +35,7 @@ defmodule OriginSimulator.SimulationTest do
     end
 
     test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, 1000..1200}
+      assert Simulation.state(:simulation) == {200, [1000,1200]}
     end
 
     test "recipe() returns the loaded recipe" do


### PR DESCRIPTION
Change recipes definition to set timings in `s` and `ms`.

An example:

```JSON
{
    "origin": "https://www.bbc.co.uk/news",
    "stages": [
        { "at": 0,    "status": 404, "latency": "50ms"},
        { "at": "4s", "status": 503, "latency": "2s"},
        { "at": "9s", "status": 200, "latency": "100ms..200ms"}
    ]
}
```