### PR TITLE
Define random content inside the posted body

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ simulate JSON contracts, structured text, etc.
 
 ```json
 {
-    "body": "{\"data\":\"<<256kb>>\", \"metadata\":\"<<128b>>and<<16b>>\"}",
+    "body": "{\"data\":\"<<256kb>>\", \"metadata\":\"<<128b>>and<<16b>>\", \"collection\":[\"<<128kb>>\", \"<<256kb>>\"]}\"}",
     "stages": [
         {
             "at": 0,

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ In this example content is posted along with the recipe. Where the payload body 
 }
 ```
 
+It's also possible to define random content inside the posted body. This can be useful to
+simulate JSON contracts, structured text, etc.
+
+```json
+{
+    "body": "{\"data\":\"<<256kb>>\", \"metadata\":\"<<128b>>and<<16b>>\"}",
+    "stages": [
+        {
+            "at": 0,
+            "latency": "100ms",
+            "status": 200
+        }
+    ]
+}
+```
+
 ## Usage
 
 You can post recipes using `curl` and the `mix upload_recipe` task.

--- a/lib/origin_simulator/body.ex
+++ b/lib/origin_simulator/body.ex
@@ -1,5 +1,5 @@
 defmodule OriginSimulator.Body do
-  @regex ~r"{{(.+?)}}"
+  @regex ~r"<<(.+?)>>"
 
   alias OriginSimulator.Size
 

--- a/lib/origin_simulator/body.ex
+++ b/lib/origin_simulator/body.ex
@@ -1,0 +1,17 @@
+defmodule OriginSimulator.Body do
+  @regex ~r"{{(.+?)}}"
+
+  alias OriginSimulator.Size
+
+  def parse(str) do
+    Regex.replace(@regex, str, fn _whole, tag -> randomise(tag) end)
+  end
+
+  def randomise(tag) do
+    size_in_bytes = Size.parse(tag)
+
+    :crypto.strong_rand_bytes(size_in_bytes)
+    |> Base.encode64
+    |> binary_part(0, size_in_bytes)
+  end
+end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -1,7 +1,7 @@
 defmodule OriginSimulator.Payload do
   use GenServer
 
-  alias OriginSimulator.{Recipe, Size}
+  alias OriginSimulator.{Body, Recipe, Size}
 
   ## Client API
 
@@ -57,20 +57,14 @@ defmodule OriginSimulator.Payload do
 
   @impl true
   def handle_call({:parse, body}, _from, state) do
-    :ets.insert(:payload, {"body", body})
+    :ets.insert(:payload, {"body", Body.parse(body)})
 
     {:reply, :ok, state}
   end
 
   @impl true
   def handle_call({:generate, size}, _from, state) do
-    size_in_bytes = Size.parse(size)
-
-    body = :crypto.strong_rand_bytes(size_in_bytes)
-    |> Base.encode64
-    |> binary_part(0, size_in_bytes)
-
-    :ets.insert(:payload, {"body", body })
+    :ets.insert(:payload, {"body", Body.randomise(size) })
 
     {:reply, :ok, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OriginSimulator.MixProject do
   def project do
     [
       app: :origin_simulator,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/origin_simulator/body_test.exs
+++ b/test/origin_simulator/body_test.exs
@@ -1,0 +1,24 @@
+defmodule OriginSimulator.RandomiserTest do
+  use ExUnit.Case
+
+  alias OriginSimulator.Body
+
+  describe "parsing a string containg placeholders" do
+    test "keeps text outside of placeholders " do
+      parsed_string = Body.parse("abc{{4b}}def{{8b}}ghi")
+      assert parsed_string =~ "abc"
+    end
+
+    test "replaces placeholders with random content " do
+      parsed_string = Body.parse("abc{{4b}}def{{8b}}ghi")
+      refute parsed_string =~ ~r"{{.+?}}"
+    end
+  end
+
+  describe "parsing a string with no placeholders" do
+    test "returns the same string content " do
+      string = "abcdefghi"
+      assert Body.parse(string) == string
+    end
+  end
+end

--- a/test/origin_simulator/body_test.exs
+++ b/test/origin_simulator/body_test.exs
@@ -21,9 +21,14 @@ defmodule OriginSimulator.RandomiserTest do
       assert parsed_string =~ "some random"
     end
 
-    test "replaces placeholders with random content " do
+    test "replaces placeholders with random content" do
       parsed_string = Body.parse("{\"data\":\"some random<<4kb>>and also<<10kb>>this\"}")
       refute parsed_string =~ ~r"<<.+?>>"
+    end
+
+    test "produces a random string of the expected size" do
+      decoded_body = Body.parse("{\"data\":\"some random<<4kb>>and also<<10kb>>this\"}")  |> Poison.decode!()
+      assert String.length(decoded_body["data"]) == 14_359
     end
   end
 

--- a/test/origin_simulator/body_test.exs
+++ b/test/origin_simulator/body_test.exs
@@ -3,15 +3,27 @@ defmodule OriginSimulator.RandomiserTest do
 
   alias OriginSimulator.Body
 
-  describe "parsing a string containg placeholders" do
+  describe "parsing a string containg a placeholder" do
     test "keeps text outside of placeholders " do
-      parsed_string = Body.parse("abc{{4b}}def{{8b}}ghi")
-      assert parsed_string =~ "abc"
+      decoded_body = Body.parse("{\"data\":\"<<1kb>>\"}") |> Poison.decode!()
+      assert String.length(decoded_body["data"]) == 1024
+    end
+
+    test "replaces placeholders with random content" do
+      parsed_string = Body.parse("{\"data\":\"some random<<4kb>>and also<<10kb>>this\"}")
+      refute parsed_string =~ ~r"<<.+?>>"
+    end
+  end
+
+  describe "parsing a string containg multiple placeholders" do
+    test "keeps text outside of placeholders " do
+      parsed_string = Body.parse("{\"data\":\"some random<<4kb>>and also<<10kb>>this\"}")
+      assert parsed_string =~ "some random"
     end
 
     test "replaces placeholders with random content " do
-      parsed_string = Body.parse("abc{{4b}}def{{8b}}ghi")
-      refute parsed_string =~ ~r"{{.+?}}"
+      parsed_string = Body.parse("{\"data\":\"some random<<4kb>>and also<<10kb>>this\"}")
+      refute parsed_string =~ ~r"<<.+?>>"
     end
   end
 


### PR DESCRIPTION
Allows to define random content inside the posted body. This can be useful to
simulate JSON contracts, structured text, etc.

```json
{
    "body": "{\"data\":\"<<256kb>>\", \"metadata\":\"<<128b>>and<<16b>>\"}",
    "stages": [
        {
            "at": 0,
            "latency": "100ms",
            "status": 200
        }
    ]
}
```