### PR TITLE
WIP: Add support for multi-route simulations (recipe books)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+config :origin_simulator, http_client: OriginSimulator.HTTPClient

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+config :origin_simulator, http_client: OriginSimulator.HTTPClient

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -12,8 +12,8 @@ defmodule OriginSimulator do
     |> send_resp(200, "ok!")
   end
 
-  get "/current_recipe" do
-    msg = Simulation.recipe_book(:simulation) || "Not set, please POST a recipe book to /add_recipe"
+  get "/current_recipe_book" do
+    msg = Simulation.recipe_book(:simulation) || "Not set, please POST a recipe book to /add_recipe_book"
 
     conn
     |> put_resp_content_type("application/json")
@@ -34,8 +34,9 @@ defmodule OriginSimulator do
     |> send_resp(200, Poison.encode!(Counter.value()))
   end
 
-  post "/add_recipe" do
+  post "/add_recipe_book" do
     Simulation.restart
+    Payload.restart
     Process.sleep(10)
 
     recipe_book = RecipeBook.parse(Plug.Conn.read_body(conn))

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -13,7 +13,7 @@ defmodule OriginSimulator do
   end
 
   get "/current_recipe" do
-    msg = Simulation.recipe(:simulation) || "Not set, please POST a recipe book to /add_recipe"
+    msg = Simulation.recipe(:simulation) || "Not set, please POST a recipe to /add_recipe"
 
     conn
     |> put_resp_content_type("application/json")

--- a/lib/origin_simulator/http_client.ex
+++ b/lib/origin_simulator/http_client.ex
@@ -1,9 +1,5 @@
 defmodule OriginSimulator.HTTPClient do
-  def get(_endpoint, :test) do
-    {:ok,  %HTTPoison.Response{body: "some content from origin"}}
-  end
-
-  def get(endpoint, _env) do
+  def get(endpoint) do
     headers = []
     options = [recv_timeout: 3000]
 

--- a/lib/origin_simulator/http_mock_client.ex
+++ b/lib/origin_simulator/http_mock_client.ex
@@ -1,5 +1,5 @@
 defmodule OriginSimulator.HTTPMockClient do
   def get(_endpoint) do
-    {:ok, %{ body: "some content from origin" }}
+    {:ok, %HTTPoison.Response{body: "some content from origin" }}
   end
 end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -6,33 +6,33 @@ defmodule OriginSimulator.Payload do
   ## Client API
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: :payload)
+    GenServer.start_link(__MODULE__, opts, name: :payloads)
   end
 
-  def fetch(server, %Recipe{origin: value}) when is_binary(value) do
-    GenServer.call(server, {:fetch, value})
+  def fetch(server, %Recipe{origin: value, route: route}) when is_binary(value) do
+    GenServer.call(server, {:fetch, route, value})
   end
 
-  def fetch(server, %Recipe{body: value}) when is_binary(value) do
-    GenServer.call(server, {:parse, value})
+  def fetch(server, %Recipe{body: value, route: route}) when is_binary(value) do
+    GenServer.call(server, {:parse, route, value})
   end
 
-  def fetch(server, %Recipe{random_content: value}) when is_binary(value) do
-    GenServer.call(server, {:generate, value})
+  def fetch(server, %Recipe{random_content: value, route: route}) when is_binary(value) do
+    GenServer.call(server, {:generate, route, value})
   end
 
-  def body(_server, status) do
+  def body(_server, status, route) do
     case status do
-      200 -> cache_lookup()
+      200 -> cache_lookup(route)
       404 -> {:ok, "Not found"}
       406 -> {:ok, "Recipe not set, please POST a recipe to /add_recipe"}
       _   -> {:ok, "Error #{status}"}
     end
   end
 
-  defp cache_lookup() do
-    case :ets.lookup(:payload, "body") do
-      [{"body", body}] -> {:ok, body}
+  defp cache_lookup(route) do
+    case :ets.lookup(:payloads, route) do
+      [{^route, body}] -> {:ok, body}
       [] -> {:error, "content not found"}
     end
   end
@@ -41,30 +41,30 @@ defmodule OriginSimulator.Payload do
 
   @impl true
   def init(_) do
-    :ets.new(:payload, [:set, :protected, :named_table, read_concurrency: true])
+    :ets.new(:payloads, [:set, :protected, :named_table, read_concurrency: true])
     {:ok, nil}
   end
 
   @impl true
-  def handle_call({:fetch, origin}, _from, state) do
+  def handle_call({:fetch, route, origin}, _from, state) do
     env = Application.get_env(:origin_simulator, :env)
 
     {:ok, %HTTPoison.Response{body: body}} = OriginSimulator.HTTPClient.get(origin, env)
-    :ets.insert(:payload, {"body", body})
+    :ets.insert(:payloads, {route, body})
 
     {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:parse, body}, _from, state) do
-    :ets.insert(:payload, {"body", Body.parse(body)})
+  def handle_call({:parse, route, body}, _from, state) do
+    :ets.insert(:payloads, {route, Body.parse(body)})
 
     {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:generate, size}, _from, state) do
-    :ets.insert(:payload, {"body", Body.randomise(size) })
+  def handle_call({:generate, route, size}, _from, state) do
+    :ets.insert(:payloads, {route, Body.randomise(size) })
 
     {:reply, :ok, state}
   end

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,9 +1,4 @@
 defmodule OriginSimulator.Recipe do
   defstruct route: '/', origin: nil, body: nil, random_content: nil, stages: []
   @type t :: %__MODULE__{route: String.t(), origin: String.t(), body: String.t(), random_content: String.t()}
-
-  # @spec parse({:ok, binary(), any()}) :: binary()
-  # def parse({:ok, body, _conn}) do
-  #   Poison.decode!(body, as: %__MODULE__{})
-  # end
 end

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,4 +1,7 @@
 defmodule OriginSimulator.Recipe do
-  defstruct route: '/', origin: nil, body: nil, random_content: nil, stages: []
-  @type t :: %__MODULE__{route: String.t(), origin: String.t(), body: String.t(), random_content: String.t()}
+  alias OriginSimulator.{RecipeRoute}
+
+  def parse({:ok, body, _conn}) do
+    Poison.decode!(body, as: [%RecipeRoute{}])
+  end
 end

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,9 +1,9 @@
 defmodule OriginSimulator.Recipe do
-  defstruct origin: nil, body: nil, random_content: nil, stages: []
-  @type t :: %__MODULE__{origin: String.t(), body: String.t(), random_content: String.t()}
+  defstruct route: '/', origin: nil, body: nil, random_content: nil, stages: []
+  @type t :: %__MODULE__{route: String.t(), origin: String.t(), body: String.t(), random_content: String.t()}
 
-  @spec parse({:ok, binary(), any()}) :: binary()
-  def parse({:ok, body, _conn}) do
-    Poison.decode!(body, as: %__MODULE__{})
-  end
+  # @spec parse({:ok, binary(), any()}) :: binary()
+  # def parse({:ok, body, _conn}) do
+  #   Poison.decode!(body, as: %__MODULE__{})
+  # end
 end

--- a/lib/origin_simulator/recipe_book.ex
+++ b/lib/origin_simulator/recipe_book.ex
@@ -1,7 +1,0 @@
-defmodule OriginSimulator.RecipeBook do
-  alias OriginSimulator.{Recipe}
-
-  def parse({:ok, body, _conn}) do
-    Poison.decode!(body, as: [%Recipe{}])
-  end
-end

--- a/lib/origin_simulator/recipe_book.ex
+++ b/lib/origin_simulator/recipe_book.ex
@@ -3,6 +3,5 @@ defmodule OriginSimulator.RecipeBook do
 
   def parse({:ok, body, _conn}) do
     Poison.decode!(body, as: [%Recipe{}])
-    # |> Enum.into(%{}, fn {route, recipe} -> {route, struct(%Recipe{}, recipe)} end)
   end
 end

--- a/lib/origin_simulator/recipe_book.ex
+++ b/lib/origin_simulator/recipe_book.ex
@@ -1,0 +1,8 @@
+defmodule OriginSimulator.RecipeBook do
+  alias OriginSimulator.{Recipe}
+
+  def parse({:ok, body, _conn}) do
+    Poison.decode!(body, as: [%Recipe{}])
+    # |> Enum.into(%{}, fn {route, recipe} -> {route, struct(%Recipe{}, recipe)} end)
+  end
+end

--- a/lib/origin_simulator/recipe_route.ex
+++ b/lib/origin_simulator/recipe_route.ex
@@ -1,0 +1,4 @@
+defmodule OriginSimulator.RecipeRoute do
+  defstruct pattern: "/*", origin: nil, body: nil, random_content: nil, stages: []
+  @type t :: %__MODULE__{pattern: String.t(), origin: String.t(), body: String.t(), random_content: String.t()}
+end

--- a/lib/origin_simulator/routing_table.ex
+++ b/lib/origin_simulator/routing_table.ex
@@ -4,7 +4,7 @@ defmodule OriginSimulator.RoutingTable do
   ## Client API
   
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: :routing_table)
+    GenServer.start_link(__MODULE__, :ok, opts)
   end
 
   def find_route(server, path) do
@@ -34,12 +34,13 @@ defmodule OriginSimulator.RoutingTable do
   end
 
   @impl true
-  def handle_call({:update_routing_table, recipe}, _from, _state) do
+  def handle_call({:update_routing_table, recipe}, _from, state) do
     routing_table = Enum.map(recipe, fn route ->
       Regex.compile!(route.pattern)
       route.pattern
     end)
-
     {:reply, :ok, routing_table}
+  rescue
+    Regex.CompileError -> {:reply, :error, state} 
   end
 end

--- a/lib/origin_simulator/routing_table.ex
+++ b/lib/origin_simulator/routing_table.ex
@@ -1,0 +1,45 @@
+defmodule OriginSimulator.RoutingTable do
+  use GenServer
+
+  ## Client API
+  
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: :routing_table)
+  end
+
+  def find_route(server, path) do
+    GenServer.call(server, :routing_table)
+    |> Enum.find(fn pattern -> String.match?(path, Regex.compile!(pattern)) end)
+    |> case do
+         nil     -> {:error, "The request path doesn't match any of the defined routes"}
+         pattern -> {:ok, pattern}
+       end
+  end
+
+  def update_routing_table(server, recipe) do
+    GenServer.call(server, {:update_routing_table, recipe})
+  end
+  
+
+  ## Server Callbacks
+  
+  @impl true
+  def init(_) do
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_call(:routing_table, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_call({:update_routing_table, recipe}, _from, _state) do
+    routing_table = Enum.map(recipe, fn route ->
+      Regex.compile!(route.pattern)
+      route.pattern
+    end)
+
+    {:reply, :ok, routing_table}
+  end
+end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -50,9 +50,7 @@ defmodule OriginSimulator.Simulation do
 
   @impl true
   def handle_call({:add_recipe_book, new_recipe_book}, _caller, state) do
-    Enum.each(new_recipe_book, fn recipe ->
-      Payload.fetch(:payloads, recipe)
-    end)
+    Payload.update_recipe_book(:payloads, new_recipe_book)
 
     Enum.map(new_recipe_book, fn recipe ->
       Enum.map(recipe.stages, fn stage ->

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -7,7 +7,7 @@ defmodule OriginSimulator.Simulation do
   ## Client API
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: :simulation)
+    GenServer.start_link(__MODULE__, :ok, opts)
   end
 
   def state(server, pattern) do
@@ -49,8 +49,8 @@ defmodule OriginSimulator.Simulation do
   end
 
   @impl true
-  def handle_call({:add_recipe, new_recipe}, _caller, state) do
-    RoutingTable.update_routing_table(:routing_table, new_recipe)
+  def handle_call({:add_recipe, new_recipe}, _from, state) do
+    :ok = RoutingTable.update_routing_table(:routing_table, new_recipe)
     Payload.update_payloads(:payloads, new_recipe)
 
     Enum.each(new_recipe, fn route ->

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -8,10 +8,10 @@ defmodule OriginSimulator.Supervisor do
   @impl true
   def init(_init_arg) do
     children = [
-      OriginSimulator.Simulation,
+      {OriginSimulator.Simulation, name: :simulation},
       {OriginSimulator.Payload, name: :payloads},
       OriginSimulator.Counter,
-      OriginSimulator.RoutingTable
+      {OriginSimulator.RoutingTable, name: :routing_table}
     ]
 
     opts = [

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -9,8 +9,9 @@ defmodule OriginSimulator.Supervisor do
   def init(_init_arg) do
     children = [
       OriginSimulator.Simulation,
-      OriginSimulator.Payload,
-      OriginSimulator.Counter
+      {OriginSimulator.Payload, name: :payloads},
+      OriginSimulator.Counter,
+      OriginSimulator.RoutingTable
     ]
 
     opts = [

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -1,12 +1,15 @@
 defmodule OriginSimulatorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: :true
   use Plug.Test
+
+  alias OriginSimulator.{Simulation}
 
   doctest OriginSimulator
 
   setup do
-    OriginSimulator.Simulation.restart()
-    Process.sleep(10)
+    simulation = start_supervised!(Simulation)
+
+    %{simulation: simulation}
   end
 
   describe "GET /status" do
@@ -31,12 +34,12 @@ defmodule OriginSimulatorTest do
     end
 
     test "will return the payload if set" do
-      payload = %{
+      payload = [%{
         "origin" => "https://www.bbc.co.uk/news",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms"}],
         "random_content" => nil,
         "body"   => nil
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -50,12 +53,12 @@ defmodule OriginSimulatorTest do
     end
 
     test "will return the payload if set for ranged latencies" do
-      payload = %{
+      payload = [%{
         "origin" => "https://www.bbc.co.uk/news",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms..200ms"}],
         "random_content" => nil,
         "body"   => nil
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -71,10 +74,10 @@ defmodule OriginSimulatorTest do
 
   describe "GET page with origin" do
     test "will return the origin page" do
-      payload = %{
+      payload = [%{
         "origin" => "https://www.bbc.co.uk/news",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -92,10 +95,10 @@ defmodule OriginSimulatorTest do
 
   describe "GET page with content" do
     test "will return the passed content" do
-      payload = %{
+      payload = [%{
         "body" =>   "{\"hello\":\"world\"}",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -113,10 +116,10 @@ defmodule OriginSimulatorTest do
 
   describe "GET page with random content" do
     test "will return random content of the passed size" do
-      payload = %{
+      payload = [%{
         "random_content" =>   "50kb",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -134,10 +137,10 @@ defmodule OriginSimulatorTest do
 
   describe "GET page with random latency within range" do
     test "will return the origin page" do
-      payload = %{
+      payload = [%{
         "body" =>   "{\"hello\":\"world\"}",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => "10ms..50ms"}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -155,10 +158,10 @@ defmodule OriginSimulatorTest do
 
   describe "POST page with origin" do
     test "will return the simulated page" do
-      payload = %{
+      payload = [%{
         "origin" => "https://www.bbc.co.uk/news",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 
@@ -176,10 +179,10 @@ defmodule OriginSimulatorTest do
 
   describe "POST page with content" do
     test "will return the simulated page" do
-      payload = %{
+      payload = [%{
         "body" =>   "{\"hello\":\"world\"}",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => 0}]
-      }
+      }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])
 

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -35,6 +35,7 @@ defmodule OriginSimulatorTest do
 
     test "will return the payload if set" do
       payload = [%{
+        "pattern" => "/foo",
         "origin" => "https://www.bbc.co.uk/news",
         "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms"}],
         "random_content" => nil,
@@ -54,10 +55,11 @@ defmodule OriginSimulatorTest do
 
     test "will return the payload if set for ranged latencies" do
       payload = [%{
-        "origin" => "https://www.bbc.co.uk/news",
-        "stages" => [%{ "at" => 0, "status" => 200, "latency" => "100ms..200ms"}],
+        "pattern" => "/foo",
+        "origin"  => "https://www.bbc.co.uk/news",
+        "stages"  => [%{ "at" => 0, "status" => 200, "latency" => "100ms..200ms"}],
         "random_content" => nil,
-        "body"   => nil
+        "body"    => nil
       }]
 
       conn(:post, "/add_recipe", Poison.encode!(payload)) |> OriginSimulator.call([])

--- a/test/origin_simulator/recipe_test.exs
+++ b/test/origin_simulator/recipe_test.exs
@@ -1,9 +1,19 @@
 defmodule OriginSimulator.RecipeTest do
   use ExUnit.Case, async: true
 
-  alias OriginSimulator.Recipe
+  alias OriginSimulator.{Recipe,RecipeRoute}
 
   test "Parse valid JSON" do
-    assert Recipe.parse({:ok, ~s[{"random_content": "123kb"}], nil}) ==  %OriginSimulator.Recipe{random_content: "123kb"}
+    assert Recipe.parse({:ok, ~s([{"random_content": "123kb"}]), nil}) == [%RecipeRoute{random_content: "123kb"}]
+  end
+
+  test "Have a default pattern" do
+    %RecipeRoute{pattern: expected} = List.first(Recipe.parse({:ok, ~s([{"random_content": "123kb"}]), nil}))
+
+    assert expected == "/*"
+  end
+
+  test "Supports multiple routes" do
+    assert Recipe.parse({:ok, ~s([{"random_content": "123kb"}, {"body": "test"}]), nil}) == [%RecipeRoute{random_content: "123kb"}, %RecipeRoute{body: "test"}]
   end
 end

--- a/test/origin_simulator/routing_table.ex
+++ b/test/origin_simulator/routing_table.ex
@@ -1,0 +1,54 @@
+defmodule OriginSimulator.RoutingTableTest do
+  use ExUnit.Case, async: true
+  alias OriginSimulator.{RoutingTable,RecipeRoute}
+
+  setup do
+    routing_table = start_supervised!(RoutingTable)
+
+    %{routing_table: routing_table}
+  end
+
+  describe "storing the routing table" do
+    test "update the routing table if all of the routes are valid", %{routing_table: routing_table} do
+      assert :ok == RoutingTable.update_routing_table(routing_table, [%RecipeRoute{pattern: "/*"}])
+    end
+
+    test "return an error if any of the routes are invalid", %{routing_table: routing_table} do
+      assert :error == RoutingTable.update_routing_table(routing_table, [%RecipeRoute{pattern: "*/"}])
+    end
+  end
+
+  describe "find route" do
+    test "finds matches", %{routing_table: routing_table} do
+      RoutingTable.update_routing_table(routing_table, [%RecipeRoute{pattern: "/foo"}])
+
+      assert RoutingTable.find_route(routing_table, "/foo") == {:ok, "/foo"}
+      assert RoutingTable.find_route(routing_table, "/foobar") == {:ok, "/foo"}
+    end
+
+    test "with multiple routes", %{routing_table: routing_table} do
+      RoutingTable.update_routing_table(routing_table, [
+            %RecipeRoute{pattern: "/foo"},
+            %RecipeRoute{pattern: "/bar"}
+          ])
+
+      assert RoutingTable.find_route(routing_table, "/bar") == {:ok, "/bar"}
+    end
+
+
+    test "finds the first matching route", %{routing_table: routing_table} do
+      RoutingTable.update_routing_table(routing_table, [
+            %RecipeRoute{pattern: "/foo"},
+            %RecipeRoute{pattern: "/foobar"}
+          ])
+
+      assert RoutingTable.find_route(routing_table, "/foo") == {:ok, "/foo"}
+    end
+
+    test "return an error if the pattern doesn't match any of the routes", %{routing_table: routing_table} do
+      RoutingTable.update_routing_table(routing_table, [])
+
+      assert RoutingTable.find_route(routing_table, "/foo") == {:error, "The request path doesn't match any of the defined routes"}
+    end
+  end
+end

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -1,83 +1,83 @@
 defmodule OriginSimulator.SimulationTest do
   use ExUnit.Case
 
-  alias OriginSimulator.Simulation
+  alias OriginSimulator.{Simulation,RecipeRoute}
 
-  def test_recipe() do
-    %OriginSimulator.Recipe{origin: "foo",
-                            stages: [%{"at" => 0, "status" => 200, "latency" => "1s"}]}
-  end
+  # def test_recipe() do
+  #   [RecipeRoute{origin: "foo",
+  #                stages: [%{"at" => 0, "status" => 200, "latency" => "1s"}]}]
+  # end
 
-  def test_range_recipe() do
-    %OriginSimulator.Recipe{origin: "foo",
-                            stages: [%{"at" => 0, "status" => 200, "latency" => "1s..1200ms"}]}
-  end
+  # def test_range_recipe() do
+  #   [RecipeRoute{origin: "foo",
+  #                stages: [%{"at" => 0, "status" => 200, "latency" => "1s..1200ms"}]}]
+  # end
 
-  def test_recipe_with_multiple_stages() do
-    %OriginSimulator.Recipe{origin: "foo",
-                            stages: [%{"at" => 0, "status" => 200, "latency" => "0s"},
-                                     %{"at" => "60ms", "status" => 503, "latency" => "1s"}]}
-  end
+  # def test_recipe_with_multiple_stages() do
+  #   [RecipeRoute{origin: "foo",
+  #                stages: [%{"at" => 0, "status" => 200, "latency" => "0s"},
+  #                         %{"at" => "60ms", "status" => 503, "latency" => "1s"}]}]
+  # end
 
-  describe "with loaded recipe" do
-    setup do
-      Simulation.add_recipe(:simulation, test_recipe())
-      Process.sleep(5)
-    end
+  # describe "with loaded recipe" do
+  #   setup do
+  #     Simulation.add_recipe(:simulation, test_recipe())
+  #     Process.sleep(5)
+  #   end
 
-    test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, 1000}
-    end
+  #   test "state() returns a tuple with http status and latency in ms" do
+  #     assert Simulation.state(:simulation) == {200, 1000}
+  #   end
 
-    test "recipe() returns the loaded recipe" do
-      assert Simulation.recipe(:simulation) == test_recipe()
-    end
-  end
+  #   test "recipe() returns the loaded recipe" do
+  #     assert Simulation.recipe(:simulation) == test_recipe()
+  #   end
+  # end
 
-  describe "with a recipe containing a range" do
-    setup do
-      Simulation.add_recipe(:simulation, test_range_recipe())
-      Process.sleep(5)
-    end
+  # describe "with a recipe containing a range" do
+  #   setup do
+  #     Simulation.add_recipe(:simulation, test_range_recipe())
+  #     Process.sleep(5)
+  #   end
 
-    test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, 1000..1200}
-    end
+  #   test "state() returns a tuple with http status and latency in ms" do
+  #     assert Simulation.state(:simulation) == {200, 1000..1200}
+  #   end
 
-    test "recipe() returns the loaded recipe" do
-      assert Simulation.recipe(:simulation) == test_range_recipe()
-    end
-  end
+  #   test "recipe() returns the loaded recipe" do
+  #     assert Simulation.recipe(:simulation) == test_range_recipe()
+  #   end
+  # end
 
-  describe "with a recipe containing multiple stages" do
-    setup do
-      Simulation.add_recipe(:simulation, test_recipe_with_multiple_stages())
-      Process.sleep(5)
-    end
+  # describe "with a recipe containing multiple stages" do
+  #   setup do
+  #     Simulation.add_recipe(:simulation, test_recipe_with_multiple_stages())
+  #     Process.sleep(5)
+  #   end
 
-    test "state() returns a tuple with http status and latency in ms" do
-      assert Simulation.state(:simulation) == {200, 0}
-      Process.sleep(80)
-      assert Simulation.state(:simulation) == {503, 1000}
-    end
+  #   test "state() returns a tuple with http status and latency in ms" do
+  #     assert Simulation.state(:simulation) == {200, 0}
+  #     Process.sleep(80)
+  #     assert Simulation.state(:simulation) == {503, 1000}
+  #   end
 
-    test "recipe() returns the loaded recipe" do
-      assert Simulation.recipe(:simulation) == test_recipe_with_multiple_stages()
-    end
-  end
+  #   test "recipe() returns the loaded recipe" do
+  #     assert Simulation.recipe(:simulation) == test_recipe_with_multiple_stages()
+  #   end
+  # end
 
-  describe "with no recipe loaded" do
-    setup do
-      Simulation.restart()
-      Process.sleep(5)
-    end
+  # describe "with no recipe loaded" do
+  #   setup do
+  #     Simulation.restart()
+  #     Process.sleep(5)
+  #   end
 
-    test "state() returns a tuple with default values" do
-      assert Simulation.state(:simulation) == {406, 0}
-    end
+  #   test "state() returns a tuple with default values" do
+  #     assert Simulation.state(:simulation) == {406, 0}
+  #   end
 
-    test "recipe() returns nil" do
-      assert Simulation.recipe(:simulation) == nil
-    end
-  end
+  #   test "recipe() returns nil" do
+  #     assert Simulation.recipe(:simulation) == nil
+  #   end
+  # end
 end


### PR DESCRIPTION
__This is a WIP PR!__

This PR aims to add support for multi-route simulations. The problem is that such a change will require significant changes in the current REST interface. We propose to replace "recipes" with "recipe books". A recipe book will be an array of JSON object pretty much the same to the recipe objects that the `/add_recipe` endpoint accepts. However, each of the recipes in a recipe book will have an extra `route` attribute. This attribute will represent the endpoint that will return responses for the recipe simulation.

An example recipe book looks like this:

```json
[  
   {  
      "route":"/example/endpoint",
      "body":"Example body",
      "stages":[
         { "at":0, "latency":"400ms", "status":200 },
         { "at":"1s", "latency":"100ms", "status":503}
      ]
   },
   {  
      "route":"/news",
      "origin":"https://www.bbc.co.uk/news",
      "stages":[  
         { "at":0, "status":404, "latency":"50ms" },
         { "at":"2s", "status":503, "latency":"2s" },
         { "at":"4s", "status":200, "latency":"100ms" }
      ]
   }
]
```

Sending a `POST` request to the `/add_recipe_book` endpoint will start new simualtion for each of the recipes in the recipe book. Each of the simulations will be independent of the rest and will be available on the endpoint specified in the `route` attribute.

If we add the above recipe book, the simulation will execute in the following manner
```
/example/endpoint

  0s          1s                                                  ∞
  *───────────*───────────────────────────────────────────────────▶

  HTTP 200 400ms                  HTTP 503 100ms

-------------------------------------------------------------------------------

/news

  0s                     2s                   4s                  ∞
  *──────────────────────*────────────────────*───────────────────▶

       HTTP 404 50ms           HTTP 503 2s       HTTP 200 100ms
```