### PR TITLE
chore(docs): Migrate Load Tests results from the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ concurrent requests.
 
 ![100ms latency chart](/gnuplot/response_time_1s_latency.png)
 
+## Load Tests
+
+For details on Load Test results visit the [Load Tests](https://github.com/bbc/origin_simulator/wiki/Load-Tests) Wiki section.
+
 ## Docker
 
 > **NOTE:** if you plan to use OriginSimulator from Docker for Mac via `docker-compose up` you might notice slow response times.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ concurrent requests.
 
 ## Load Tests
 
-For details on Load Test results visit the [Load Tests](https://github.com/bbc/origin_simulator/wiki/Load-Tests) Wiki section.
+For details on Load Test results visit the [Load Tests](docs/load-test-results/) results docs.
 
 ## Docker
 

--- a/docs/load-test-results/2019-01-15.md
+++ b/docs/load-test-results/2019-01-15.md
@@ -1,0 +1,208 @@
+# Load tests
+- 15th January 2019
+- Instance: t3.medium
+
+## Findings
+These load tests have revealed a performance bottleneck caused by 
+storing a large response in the Payload genserver. You can see from 
+the load tests bellow that when serving a large payload such as the 
+news homepage, the latency takes a big hit, and affects the number 
+of RPS the app can handle. This is compared to a much smaller payload 
+of roughly 100 characters where it can handle 2000rps with a latency 
+of 1.88ms.
+
+## Next steps
+Try using an ETS cache in the Payload genserver that shares access to
+other processes.
+
+### t3.medium
+
+#### Large payload from origin (news front page):
+1k rps
+```
+wrk -t2 -c10 -d30s -R1000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+
+  Thread calibration: mean lat.: 4.248ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 3.166ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     3.32ms    2.74ms  57.79ms   95.38%
+    Req/Sec   526.55     97.43     1.11k    79.05%
+  29994 requests in 30.00s, 11.97GB read
+Requests/sec:    999.73
+Transfer/sec:    408.67MB
+```
+
+2k rps
+```
+wrk -t2 -c10 -d30s -R2000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+
+  Thread calibration: mean lat.: 1033.683ms, rate sampling interval: 4607ms
+  Thread calibration: mean lat.: 1421.625ms, rate sampling interval: 6221ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     4.32s     3.72s   12.09s    58.54%
+    Req/Sec   762.86    145.93     0.93k    42.86%
+  44540 requests in 30.00s, 17.78GB read
+Requests/sec:   1484.59
+Transfer/sec:    606.94MB
+```
+
+#### A much smaller payload (about 100 characters):
+1k rps
+```
+wrk -t2 -c10 -d30s -R1000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 1.702ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 1.683ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.69ms  615.50us  10.89ms   88.06%
+    Req/Sec   526.94     69.41     1.11k    77.96%
+  29994 requests in 30.00s, 6.44MB read
+Requests/sec:    999.76
+Transfer/sec:    219.67KB
+```
+
+2k rps
+```
+wrk -t2 -c10 -d30s -R2000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 1.639ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 2.099ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.88ms    6.05ms 211.20ms   99.68%
+    Req/Sec     1.06k   152.59     2.11k    66.52%
+  59982 requests in 30.00s, 12.87MB read
+Requests/sec:   1999.17
+Transfer/sec:    439.27KB
+```
+
+10k rps
+```
+wrk -t2 -c10 -d30s -R10000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 627.280ms, rate sampling interval: 2308ms
+  Thread calibration: mean lat.: 625.284ms, rate sampling interval: 2297ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     2.41s   648.08ms   3.92s    62.53%
+    Req/Sec     4.45k   204.88     4.56k    87.50%
+  262966 requests in 30.00s, 56.43MB read
+Requests/sec:   8765.51
+Transfer/sec:      1.88MB
+```
+
+#### Status endpoint for comparison
+10k rps
+```
+wrk -t2 -c10 -d30s -R10000 http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/status
+Running 30s test @ http://ec2-18-130-181-134.eu-west-2.compute.amazonaws.com:8084/status
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 1.735ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 1.817ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     6.25ms   25.23ms 227.84ms   96.05%
+    Req/Sec     5.28k   366.11     6.33k    62.87%
+  299870 requests in 30.00s, 53.48MB read
+Requests/sec:   9995.63
+Transfer/sec:      1.78MB
+```
+
+### c5.large
+
+#### Large payload from origin (news front page):
+1k rps:
+```
+wrk -t2 -c10 -d30s -R1000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 2.181ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 2.262ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     2.34ms    4.23ms 204.16ms   99.85%
+    Req/Sec   526.35     75.86     1.22k    73.60%
+  29994 requests in 30.00s, 12.28GB read
+Requests/sec:    999.70
+Transfer/sec:    419.14MB
+```
+
+2k rps:
+```
+wrk -t2 -c10 -d30s -R2000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 2.831ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 2.491ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     2.66ms  687.19us   6.98ms   63.91%
+    Req/Sec     1.05k   121.55     1.55k    75.57%
+  59982 requests in 30.00s, 24.56GB read
+Requests/sec:   1999.26
+Transfer/sec:    838.19MB
+```
+
+10k rps:
+```
+wrk -t2 -c10 -d30s -R10000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 3167.347ms, rate sampling interval: 11771ms
+  Thread calibration: mean lat.: 3790.086ms, rate sampling interval: 13656ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    13.64s     4.56s   22.99s    61.36%
+    Req/Sec     1.43k   235.00     1.66k   100.00%
+  85599 requests in 30.00s, 35.05GB read
+Requests/sec:   2853.33
+Transfer/sec:      1.17GB
+```
+
+#### A much smaller payload (about 100 characters):
+1k rps
+```
+wrk -t2 -c10 -d30s -R1000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 1.448ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 1.507ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.48ms  382.43us   5.44ms   72.05%
+    Req/Sec   534.43     68.18     0.89k    80.51%
+  29996 requests in 30.00s, 6.44MB read
+Requests/sec:    999.81
+Transfer/sec:    219.69KB
+```
+
+2k rps
+```
+wrk -t2 -c10 -d30s -R2000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+
+  Thread calibration: mean lat.: 1.536ms, rate sampling interval: 10ms
+  Thread calibration: mean lat.: 2.519ms, rate sampling interval: 10ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.53ms  367.83us   5.55ms   65.05%
+    Req/Sec     1.05k   102.42     1.50k    77.42%
+  59983 requests in 30.00s, 12.87MB read
+Requests/sec:   1999.33
+Transfer/sec:    439.31KB
+```
+
+10k rps
+```
+wrk -t2 -c10 -d30s -R10000 http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+Running 30s test @ http://ec2-18-130-64-24.eu-west-2.compute.amazonaws.com:8084/
+  2 threads and 10 connections
+  Thread calibration: mean lat.: 6.945ms, rate sampling interval: 54ms
+  Thread calibration: mean lat.: 5.645ms, rate sampling interval: 21ms
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     6.72ms   24.98ms 222.85ms   97.20%
+    Req/Sec     5.10k   188.87     5.80k    73.11%
+  299640 requests in 30.00s, 64.30MB read
+Requests/sec:   9988.06
+Transfer/sec:      2.14MB
+```


### PR DESCRIPTION
Add the load test results from the wiki to the docs and link from the readme. This makes it consistent with the approach in the Belfrage repo where we have results in https://github.com/bbc/belfrage/tree/master/docs/load-test-results.

If this is all good we can remove the wiki section. The example is pretty much covered in the readme already too.
