### PR TITLE
Fix response when no recipe is set

### DIFF
--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -1,6 +1,6 @@
 defmodule OriginSimulator do
   use Plug.Router
-  alias OriginSimulator.{Payload,Recipe,Simulation,PlugResponseCounter,Counter}
+  alias OriginSimulator.{Payload, Recipe, Simulation, PlugResponseCounter, Counter}
   plug(PlugResponseCounter)
 
   plug(:match)
@@ -35,7 +35,7 @@ defmodule OriginSimulator do
   end
 
   post "/add_recipe" do
-    Simulation.restart
+    Simulation.restart()
     Process.sleep(10)
 
     recipe = Recipe.parse(Plug.Conn.read_body(conn))
@@ -65,11 +65,16 @@ defmodule OriginSimulator do
 
     {:ok, body} = Payload.body(:payload, status)
 
+    recipe = Simulation.recipe(:simulation)
+
     conn
     |> put_resp_content_type(content_type(body))
-    |> merge_resp_headers(Simulation.recipe(:simulation).headers)
+    |> merge_resp_headers(recipe_headers(recipe))
     |> send_resp(status, body)
   end
+
+  defp recipe_headers(nil), do: []
+  defp recipe_headers(recipe), do: recipe.headers
 
   defp content_type(body) do
     if String.first(body) == "{" do

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -198,6 +198,16 @@ defmodule OriginSimulatorTest do
     end
   end
 
+  describe "GET page with no recipe" do
+    test "will return an error message if recipe has not been set" do
+      conn = conn(:get, "/") |> OriginSimulator.call([])
+
+      assert conn.state == :sent
+      assert conn.status == 406
+      assert conn.resp_body == "Recipe not set, please POST a recipe to /add_recipe"
+    end
+  end
+
   describe "POST page with origin" do
     test "will return the simulated page" do
       payload = %{


### PR DESCRIPTION
Fix bug introduced by PR #17 that throws the following exception when an arbitrary page is called.

```
11:50:42.010 [error] #PID<0.1310.0> running OriginSimulator (connection #PID<0.1308.0>, stream id 1) terminated
Server: 127.0.0.1:8080 (http)
Request: GET /data
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function nil.headers/0 is undefined
        nil.headers()
        (origin_simulator) lib/origin_simulator.ex:70: OriginSimulator.serve_payload/1
        (origin_simulator) lib/origin_simulator.ex:1: OriginSimulator.plug_builder_call/2
        (plug_cowboy) lib/plug/cowboy/handler.ex:12: Plug.Cowboy.Handler.init/2
        (cowboy) /Users/FrencS03/Development/origin_simulator/deps/cowboy/src/cowboy_handler.erl:41: :cowboy_handler.execute/2
        (cowboy) /Users/FrencS03/Development/origin_simulator/deps/cowboy/src/cowboy_stream_h.erl:296: :cowboy_stream_h.execute/3
        (cowboy) /Users/FrencS03/Development/origin_simulator/deps/cowboy/src/cowboy_stream_h.erl:274: :cowboy_stream_h.request_process/3
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3 
```