### PR TITLE
gzip response: body, random content

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,60 @@ At any time you can reset the scenario by simply POSTing a new one to `/_admin/a
 
 In multiple origins scenario, new origins and routes can be added to the existing ones through `/_admin/add_recipe`. Existing scenarios can also be updated. For example you can "take down" an origin by updating its recipe with 500 status.
 
+#### Response headers
+OriginSimulator can serve HTTP headers in responses. The headers can be specified in recipes:
+
+```json
+{
+  "route": "/news",
+  "origin": "https://www.bbc.co.uk/news",
+  "stages": [
+    {
+      "at": 0,
+      "latency": "100ms",
+      "status": 200
+    }
+  ],
+  "headers": {
+    "connection": "keepalive",
+    "cache-control": "private, max-age=0, no-cache"
+  }
+}
+```
+
+#### Response compression
+For posted and random content recipes, response compression can be specified via the `content-encoding` header. For example, the following recipe returns a gzip random content of 200kb size.
+
+```json
+{
+  "random_content": "200kb",
+  "stages": [
+      { "at": 0, "status": 200, "latency": 0}
+  ],
+  "headers": {
+    "content-encoding": "gzip"
+  }
+}
+```
+
+A corresponding `content-type` header is required for posted `body` which could be of any type (e.g. JSON, HTML, XML):
+
+```json
+{
+  "route": "/data/json",
+  "body": "{\"data\":\"<<256kb>>\", \"metadata\":\"<<128b>>and<<16b>>\", \"collection\":[\"<<128kb>>\", \"<<256kb>>\"]}\"}",
+  "stages": [
+      { "at": 0, "status": 200, "latency": 0}
+  ],
+  "headers": {
+    "content-encoding": "gzip",
+    "content-type": "application/json; charset=utf-8"
+  }
+}
+```
+
+Note: responses of recipes with HTTP origins are currently uncompressed. This will be addressed in due course.
+
 #### Using `mix upload_recipe`
 `mix upload_recipe demo` will upload the recipe located at `examples/demo.json` to origin simulator running locally.
 

--- a/examples/permanent_200_random_200kb_no_latency_gzip.json
+++ b/examples/permanent_200_random_200kb_no_latency_gzip.json
@@ -1,0 +1,14 @@
+{
+  "random_content": "200kb",
+  "stages": [
+    {
+      "at": 0,
+      "status": 200,
+      "latency": 0
+    }
+  ],
+  "headers": {
+    "content-encoding": "gzip",
+    "content-type": "text/html; charset=utf-8"
+  }
+}

--- a/lib/origin_simulator/body.ex
+++ b/lib/origin_simulator/body.ex
@@ -3,15 +3,25 @@ defmodule OriginSimulator.Body do
 
   alias OriginSimulator.Size
 
-  def parse(str) do
+  def parse(str, headers \\ %{})
+
+  def parse(str, %{"content-encoding" => "gzip"}) do
+    Regex.replace(@regex, str, fn _whole, tag -> randomise(tag) end)
+    |> :zlib.gzip()
+  end
+
+  def parse(str, _) do
     Regex.replace(@regex, str, fn _whole, tag -> randomise(tag) end)
   end
 
-  def randomise(tag) do
+  def randomise(tag, headers \\ %{})
+  def randomise(tag, %{"content-encoding" => "gzip"}), do: randomise(tag, %{}) |> :zlib.gzip()
+
+  def randomise(tag, _) do
     size_in_bytes = Size.parse(tag)
 
     :crypto.strong_rand_bytes(size_in_bytes)
-    |> Base.encode64
+    |> Base.encode64()
     |> binary_part(0, size_in_bytes)
   end
 end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -17,7 +17,8 @@ defmodule OriginSimulator.Payload do
     GenServer.call(server, {:parse, recipe, route})
   end
 
-  def fetch(server, %Recipe{random_content: value, route: route} = recipe) when is_binary(value) do
+  def fetch(server, %Recipe{random_content: value, route: route} = recipe)
+      when is_binary(value) do
     GenServer.call(server, {:generate, recipe, route})
   end
 
@@ -57,14 +58,14 @@ defmodule OriginSimulator.Payload do
 
   @impl true
   def handle_call({:parse, recipe, route}, _from, state) do
-    :ets.insert(:payload, {route, Body.parse(recipe.body)})
+    :ets.insert(:payload, {route, Body.parse(recipe.body, recipe.headers)})
 
     {:reply, :ok, state}
   end
 
   @impl true
   def handle_call({:generate, recipe, route}, _from, state) do
-    :ets.insert(:payload, {route, Body.randomise(recipe.random_content)})
+    :ets.insert(:payload, {route, Body.randomise(recipe.random_content, recipe.headers)})
 
     {:reply, :ok, state}
   end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -13,12 +13,12 @@ defmodule OriginSimulator.Payload do
     GenServer.call(server, {:fetch, value, route})
   end
 
-  def fetch(server, %Recipe{body: value, route: route}) when is_binary(value) do
-    GenServer.call(server, {:parse, value, route})
+  def fetch(server, %Recipe{body: value, route: route} = recipe) when is_binary(value) do
+    GenServer.call(server, {:parse, recipe, route})
   end
 
-  def fetch(server, %Recipe{random_content: value, route: route}) when is_binary(value) do
-    GenServer.call(server, {:generate, value, route})
+  def fetch(server, %Recipe{random_content: value, route: route} = recipe) when is_binary(value) do
+    GenServer.call(server, {:generate, recipe, route})
   end
 
   def body(_server, status, path \\ Recipe.default_route(), route \\ Recipe.default_route()) do
@@ -56,15 +56,15 @@ defmodule OriginSimulator.Payload do
   end
 
   @impl true
-  def handle_call({:parse, body, route}, _from, state) do
-    :ets.insert(:payload, {route, Body.parse(body)})
+  def handle_call({:parse, recipe, route}, _from, state) do
+    :ets.insert(:payload, {route, Body.parse(recipe.body)})
 
     {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:generate, size, route}, _from, state) do
-    :ets.insert(:payload, {route, Body.randomise(size)})
+  def handle_call({:generate, recipe, route}, _from, state) do
+    :ets.insert(:payload, {route, Body.randomise(recipe.random_content)})
 
     {:reply, :ok, state}
   end

--- a/test/fixtures/recipes.exs
+++ b/test/fixtures/recipes.exs
@@ -26,18 +26,19 @@ defmodule Fixtures.Recipes do
     }
   end
 
-  def body_recipe() do
-    %Recipe{
-      body: "{\"hello\":\"world\"}",
-      stages: [%{"at" => 0, "status" => 200, "latency" => 0}]
-    }
-  end
-
-  def body_recipe_headers() do
+  def body_recipe(headers \\ %{}) do
     %Recipe{
       body: "{\"hello\":\"world\"}",
       stages: [%{"at" => 0, "status" => 200, "latency" => 0}],
-      headers: %{"response-header" => "Value123"}
+      headers: headers
+    }
+  end
+
+  def random_content_recipe(size \\ "50kb", headers \\ %{}) do
+    %Recipe{
+      random_content: size,
+      stages: [%{"at" => 0, "status" => 200, "latency" => 0}],
+      headers: headers
     }
   end
 

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -49,8 +49,8 @@ defmodule OriginSimulatorTest do
     end
 
     test "will return the parsed body content with respond headers" do
-      payload = body_recipe_headers() |> Poison.encode!()
-      expected_header = body_recipe_headers().headers["response-header"]
+      headers = %{"response-header" => "123"}
+      payload = body_recipe(headers) |> Poison.encode!()
 
       conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
       Process.sleep(20)
@@ -59,11 +59,33 @@ defmodule OriginSimulatorTest do
       |> OriginSimulator.call([])
       |> assert_status_body(200, body_mock(type: :json))
       |> assert_resp_header({"content-type", ["application/json; charset=utf-8"]})
-      |> assert_resp_header({"response-header", [expected_header]})
+      |> assert_resp_header({"response-header", [headers["response-header"]]})
+    end
+
+    test "will return gzip parsed body with appropriate headers" do
+      headers = %{
+        "cache-control" => "public, max-age=30",
+        "connection" => "keepalive",
+        "content-encoding" => "gzip",
+        "content-type" => "application/json; charset=utf-8"
+      }
+
+      payload = body_recipe(headers) |> Poison.encode!()
+
+      conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
+      Process.sleep(20)
+
+      conn(:get, "/")
+      |> OriginSimulator.call([])
+      |> assert_status_body(200, body_mock(type: :json) |> :zlib.gzip())
+      |> assert_resp_header({"cache-control", ["public, max-age=30"]})
+      |> assert_resp_header({"content-type", ["application/json; charset=utf-8"]})
+      |> assert_resp_header({"content-encoding", ["gzip"]})
+      |> assert_resp_header({"connection", ["keepalive"]})
     end
 
     test "will return random content of the parsed size" do
-      payload = random_content_payload() |> Poison.encode!()
+      payload = random_content_recipe("50kb") |> Poison.encode!()
       conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
       Process.sleep(20)
 
@@ -74,6 +96,27 @@ defmodule OriginSimulatorTest do
       assert conn.status == 200
       assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
       assert String.length(conn.resp_body) == 50 * 1024
+    end
+
+    test "will return gzip random content with appropriate headers" do
+      headers = %{
+        "cache-control" => "public, max-age=30",
+        "connection" => "keepalive",
+        "content-encoding" => "gzip",
+        "content-type" => "text/html; charset=utf-8"
+      }
+
+      payload = random_content_recipe("50kb", headers) |> Poison.encode!()
+      conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
+      Process.sleep(20)
+
+      conn = conn(:get, "/")
+      conn = OriginSimulator.call(conn, [])
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+      assert String.length(conn.resp_body |> :zlib.gunzip()) == 50 * 1024
     end
   end
 


### PR DESCRIPTION
This PR updates OS to serve gzip `body`, `random_content` responses **on demand** via the `content-encoding` header. For example, the following recipe returns a gzip random content of 200kb size. Without the `content-encoding` header, uncompressed response is served (current behaviour).

```json
{
  "random_content": "200kb",
  "stages": [
      { "at": 0, "status": 200, "latency": 0}
  ],
  "headers": {
    "content-encoding": "gzip"
  }
}
```

Note: response compression doesn't affect the performance of OS. Compression is done one-time at recipe upload time when the specified body is parsed or generated, then compressed and stored in ETS for serving at later simulations.