### PR TITLE
gzip response: origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ OriginSimulator can serve HTTP headers in responses. The headers can be specifie
 ```
 
 #### Response compression
-For posted and random content recipes, response compression can be specified via the `content-encoding` header. For example, the following recipe returns a gzip random content of 200kb size.
+Response compression can be specified via the `content-encoding` header. For example, the following recipe returns a gzip random content of 200kb size.
 
 ```json
 {
@@ -372,7 +372,20 @@ A corresponding `content-type` header is required for posted `body` which could 
 }
 ```
 
-Note: responses of recipes with HTTP origins are currently uncompressed. This will be addressed in due course.
+For recipes with an origin, a gzip response may also be specified with the `"content-encoding": "gzip"` header. OriginSimulator will fetch content from the origin with a `accept-encoding: gzip` header. It will store and serve the gzip content from origin (if provided) during simulation.
+
+```json
+{
+  "route": "/news",
+  "origin": "https://www.bbc.co.uk/news",
+  "stages": [
+      { "at": 0, "status": 200, "latency": 0}
+  ],
+  "headers": {
+    "content-encoding": "gzip"
+  }
+}
+```
 
 #### Using `mix upload_recipe`
 `mix upload_recipe demo` will upload the recipe located at `examples/demo.json` to origin simulator running locally.

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,9 @@ use Mix.Config
 #
 #     config :logger, level: :info
 #
-config :origin_simulator, env: Mix.env()
-config :origin_simulator, http_port: 8080
-config :origin_simulator, admin_domain: "_admin"
+config :origin_simulator,
+  admin_domain: "_admin",
+  http_client: OriginSimulator.HTTPClient,
+  http_port: 8080
 
 import_config "#{Mix.env()}.exs"

--- a/examples/permanent_200_no_latency_gzip.json
+++ b/examples/permanent_200_no_latency_gzip.json
@@ -1,0 +1,10 @@
+{
+    "origin": "https://www.bbc.co.uk/news",
+    "route": "/news",
+    "stages": [
+        { "at": 0, "status": 200, "latency": 0}
+    ],
+    "headers": {
+      "content-encoding": "gzip"
+    }
+}

--- a/lib/origin_simulator/http_client.ex
+++ b/lib/origin_simulator/http_client.ex
@@ -1,8 +1,16 @@
 defmodule OriginSimulator.HTTPClient do
-  def get(endpoint) do
-    headers = []
-    options = [recv_timeout: 3000]
+  def get(endpoint, headers \\ %{})  
+  
+  def get(endpoint, %{"content-encoding" => "gzip"} = headers) do
+    new_headers = headers
+    |> Map.delete("content-encoding")
+    |> Map.put("accept-encoding", "gzip")
 
-    HTTPoison.get(endpoint, headers, options)
+    get(endpoint, new_headers)
+  end
+
+  def get(endpoint, headers) do
+    options = [recv_timeout: 3000]
+    HTTPoison.get(endpoint, headers |> Map.to_list, options)
   end
 end

--- a/lib/origin_simulator/http_client.ex
+++ b/lib/origin_simulator/http_client.ex
@@ -1,9 +1,5 @@
 defmodule OriginSimulator.HTTPClient do
-  def get(_endpoint, :test) do
-    {:ok,  %HTTPoison.Response{body: "some content from origin"}}
-  end
-
-  def get(endpoint, _env) do
+  def get(endpoint) do
     headers = []
     options = [recv_timeout: 3000]
 

--- a/lib/origin_simulator/http_mock_client.ex
+++ b/lib/origin_simulator/http_mock_client.ex
@@ -1,5 +1,5 @@
 defmodule OriginSimulator.HTTPMockClient do
   def get(endpoint, type: :html), do: get(endpoint)
-  def get(_endpoint, type: :json), do: {:ok, %{body: "{\"hello\":\"world\"}"}}
-  def get(_endpoint), do: {:ok, %{body: "some content from origin"}}
+  def get(_endpoint, type: :json), do: {:ok, %HTTPoison.Response{body: "{\"hello\":\"world\"}"}}
+  def get(_endpoint), do: {:ok, %HTTPoison.Response{body: "some content from origin"}}
 end

--- a/lib/origin_simulator/http_mock_client.ex
+++ b/lib/origin_simulator/http_mock_client.ex
@@ -1,5 +1,9 @@
 defmodule OriginSimulator.HTTPMockClient do
+  def get(_endpoint, headers \\ %{})
+
   def get(endpoint, type: :html), do: get(endpoint)
   def get(_endpoint, type: :json), do: {:ok, %HTTPoison.Response{body: "{\"hello\":\"world\"}"}}
-  def get(_endpoint), do: {:ok, %HTTPoison.Response{body: "some content from origin"}}
+
+  def get(_endpoint, %{"content-encoding" => "gzip"}), do: {:ok, %HTTPoison.Response{body: :zlib.gzip("some content from origin")}}
+  def get(_endpoint, _headers), do: {:ok, %HTTPoison.Response{body: "some content from origin"}}
 end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -3,6 +3,8 @@ defmodule OriginSimulator.Payload do
 
   alias OriginSimulator.{Body, Recipe}
 
+  @http_client Application.get_env(:origin_simulator, :http_client)
+
   ## Client API
 
   def start_link(opts) do
@@ -49,9 +51,7 @@ defmodule OriginSimulator.Payload do
 
   @impl true
   def handle_call({:fetch, origin, route}, _from, state) do
-    env = Application.get_env(:origin_simulator, :env)
-
-    {:ok, %HTTPoison.Response{body: body}} = OriginSimulator.HTTPClient.get(origin, env)
+    {:ok, %HTTPoison.Response{body: body}} = @http_client.get(origin)
     :ets.insert(:payload, {route, body})
     {:reply, :ok, state}
   end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -11,8 +11,8 @@ defmodule OriginSimulator.Payload do
     GenServer.start_link(__MODULE__, opts, name: :payload)
   end
 
-  def fetch(server, %Recipe{origin: value, route: route}) when is_binary(value) do
-    GenServer.call(server, {:fetch, value, route})
+  def fetch(server, %Recipe{origin: value, route: route} = recipe) when is_binary(value) do
+    GenServer.call(server, {:fetch, recipe, route})
   end
 
   def fetch(server, %Recipe{body: value, route: route} = recipe) when is_binary(value) do
@@ -50,8 +50,8 @@ defmodule OriginSimulator.Payload do
   end
 
   @impl true
-  def handle_call({:fetch, origin, route}, _from, state) do
-    {:ok, %HTTPoison.Response{body: body}} = @http_client.get(origin)
+  def handle_call({:fetch, recipe, route}, _from, state) do
+    {:ok, %HTTPoison.Response{body: body}} = @http_client.get(recipe.origin)
     :ets.insert(:payload, {route, body})
     {:reply, :ok, state}
   end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -51,7 +51,7 @@ defmodule OriginSimulator.Payload do
 
   @impl true
   def handle_call({:fetch, recipe, route}, _from, state) do
-    {:ok, %HTTPoison.Response{body: body}} = @http_client.get(recipe.origin)
+    {:ok, %HTTPoison.Response{body: body}} = @http_client.get(recipe.origin, recipe.headers)
     :ets.insert(:payload, {route, body})
     {:reply, :ok, state}
   end

--- a/test/fixtures/recipes.exs
+++ b/test/fixtures/recipes.exs
@@ -4,10 +4,11 @@ defmodule Fixtures.Recipes do
   def recipe(overrides \\ []), do: struct(Recipe, Keyword.merge(recipe_defaults(), overrides))
   defp recipe_defaults(), do: %Recipe{} |> Map.to_list() |> tl
 
-  def origin_recipe() do
+  def origin_recipe(headers \\ %{}) do
     %Recipe{
       origin: "https://www.bbc.co.uk/news",
-      stages: [%{"at" => 0, "status" => 200, "latency" => 0}]
+      stages: [%{"at" => 0, "status" => 200, "latency" => 0}],
+      headers: headers
     }
   end
 
@@ -15,14 +16,6 @@ defmodule Fixtures.Recipes do
     %Recipe{
       origin: "https://www.bbc.co.uk/news",
       stages: [%{"at" => 0, "status" => 200, "latency" => "100ms..200ms"}]
-    }
-  end
-
-  def origin_recipe_headers() do
-    %Recipe{
-      origin: "https://www.bbc.co.uk/news",
-      stages: [%{"at" => 0, "status" => 200, "latency" => "100ms..200ms"}],
-      headers: %{"X-Foo" => "bar"}
     }
   end
 

--- a/test/origin_simulator/admin_router_test.exs
+++ b/test/origin_simulator/admin_router_test.exs
@@ -111,7 +111,7 @@ defmodule OriginSimulator.AdminRouterTest do
     end
 
     test "will return the headers in the payload when provided" do
-      payload = [origin_recipe_headers()] |> Poison.encode!()
+      payload = [origin_recipe()] |> Poison.encode!()
       conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
 
       conn(:get, "/#{admin_domain()}/current_recipe")

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -47,4 +47,13 @@ defmodule OriginSimulator.PayloadTest do
       assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "{\"hello\":\"world\"}"}
     end
   end
+
+  describe "gzip response" do
+    test "returns the origin body for 200" do
+      recipe = %Recipe{origin: "https://www.bbc.co.uk", headers: %{"content-encoding" => "gzip"}}
+      OriginSimulator.Payload.fetch(:payload, recipe)
+
+      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, :zlib.gzip("some content from origin")}
+    end
+  end
 end

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -1,59 +1,71 @@
 defmodule OriginSimulator.PayloadTest do
   use ExUnit.Case, async: true
+  import Fixtures.Recipes
+  import OriginSimulator, only: [recipe_not_set: 0]
 
-  alias OriginSimulator.Recipe
+  alias OriginSimulator.Payload
 
   # TODO: additional tests for fetching and storing multi-origin / source content in ETS
   describe "with origin" do
     setup do
-      OriginSimulator.Payload.fetch(:payload, %Recipe{origin: "https://www.bbc.co.uk"})
+      Payload.fetch(:payload, origin_recipe())
     end
 
     test "Always return an error body for 5xx" do
-      assert OriginSimulator.Payload.body(:payload, 500) == {:ok, "Error 500"}
+      assert Payload.body(:payload, 500) == {:ok, "Error 500"}
     end
 
     test "Always return 'Not Found' for 404s" do
-      assert OriginSimulator.Payload.body(:payload, 404) == {:ok, "Not found"}
+      assert Payload.body(:payload, 404) == {:ok, "Not found"}
     end
 
     test "Suggests to add a recipe for 406" do
-      assert OriginSimulator.Payload.body(:payload, 406) == {:ok, "Recipe not set, please POST a recipe to /#{OriginSimulator.admin_domain()}/add_recipe"}
+      assert Payload.body(:payload, 406) == {:ok, recipe_not_set()}
     end
 
     test "returns the origin body for 200" do
-      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "some content from origin"}
+      assert Payload.body(:payload, 200) == {:ok, "some content from origin"}
     end
   end
 
   describe "with content" do
     setup do
-      OriginSimulator.Payload.fetch(:payload, %Recipe{body: "{\"hello\":\"world\"}"})
+      Payload.fetch(:payload, body_recipe())
     end
 
     test "Always return an error body for 5xx" do
-      assert OriginSimulator.Payload.body(:payload, 500) == {:ok, "Error 500"}
+      assert Payload.body(:payload, 500) == {:ok, "Error 500"}
     end
 
     test "Always return 'Not Found' for 404s" do
-      assert OriginSimulator.Payload.body(:payload, 404) == {:ok, "Not found"}
+      assert Payload.body(:payload, 404) == {:ok, "Not found"}
     end
 
     test "Suggests to add a recipe for 406" do
-      assert OriginSimulator.Payload.body(:payload, 406) == {:ok, "Recipe not set, please POST a recipe to /#{OriginSimulator.admin_domain()}/add_recipe"}
+      assert Payload.body(:payload, 406) == {:ok, recipe_not_set()}
     end
 
     test "returns the origin body for 200" do
-      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, "{\"hello\":\"world\"}"}
+      assert Payload.body(:payload, 200) == {:ok, "{\"hello\":\"world\"}"}
     end
   end
 
-  describe "gzip response" do
-    test "returns the origin body for 200" do
-      recipe = %Recipe{origin: "https://www.bbc.co.uk", headers: %{"content-encoding" => "gzip"}}
-      OriginSimulator.Payload.fetch(:payload, recipe)
+  describe "recipe with gzip content-encoding header" do
+    test "returns gzip body from origin" do
+      Payload.fetch(:payload, origin_recipe(%{"content-encoding" => "gzip"}))
+      assert Payload.body(:payload, 200) == {:ok, :zlib.gzip("some content from origin")}
+    end
 
-      assert OriginSimulator.Payload.body(:payload, 200) == {:ok, :zlib.gzip("some content from origin")}
+    test "returns gzip body (posted)" do
+      Payload.fetch(:payload, body_recipe(%{"content-encoding" => "gzip"}))
+      assert Payload.body(:payload, 200) == {:ok, :zlib.gzip("{\"hello\":\"world\"}")}
+    end
+
+    test "returns gzip random content" do
+      Payload.fetch(:payload, random_content_recipe("10kb", %{"content-encoding" => "gzip"}))
+      {:ok, gzip_content} = Payload.body(:payload, 200)
+
+      assert gzip_content |> :zlib.gunzip() |> String.length() == 10 * 1024
     end
   end
 end


### PR DESCRIPTION
This PR updates OriginSimulator to provide gzip origin responses on demand via the content-encoding header. For example, the following recipe returns a gzip response from an origin. Without the content-encoding header, uncompressed response is served (current behaviour).

```json
{
    "origin": "https://www.bbc.co.uk/news",
    "route": "/news",
    "stages": [
        { "at": 0, "status": 200, "latency": 0}
    ],
    "headers": {
      "content-encoding": "gzip"
    }
}
```

OriginSimulator fetches content from the origin with a `accept-encoding: gzip` header. It then stores and serves the gzip content from origin (if provided) during simulation. Hence the response compression doesn't affect the overall performance of OriginSimulator.