### PR TITLE
always return set payload body for error codes

### DIFF
--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -26,11 +26,9 @@ defmodule OriginSimulator.Payload do
 
   def body(_server, status, path \\ Recipe.default_route(), route \\ Recipe.default_route()) do
     case {status, path} do
-      {200, _} -> cache_lookup(route)
-      {404, _} -> {:ok, "Not found"}
       {406, "/*"} -> {:ok, OriginSimulator.recipe_not_set()}
       {406, _} -> {:ok, OriginSimulator.recipe_not_set(path)}
-      _ -> {:ok, "Error #{status}"}
+      _ -> cache_lookup(route)
     end
   end
 

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -11,12 +11,12 @@ defmodule OriginSimulator.PayloadTest do
       Payload.fetch(:payload, origin_recipe())
     end
 
-    test "Always return an error body for 5xx" do
-      assert Payload.body(:payload, 500) == {:ok, "Error 500"}
+    test "Always returns payload body for 5xx" do
+      assert Payload.body(:payload, 500) == {:ok, "some content from origin"}
     end
 
-    test "Always return 'Not Found' for 404s" do
-      assert Payload.body(:payload, 404) == {:ok, "Not found"}
+    test "Always returns payload body for 404s" do
+      assert Payload.body(:payload, 404) == {:ok, "some content from origin"}
     end
 
     test "Suggests to add a recipe for 406" do
@@ -33,12 +33,12 @@ defmodule OriginSimulator.PayloadTest do
       Payload.fetch(:payload, body_recipe())
     end
 
-    test "Always return an error body for 5xx" do
-      assert Payload.body(:payload, 500) == {:ok, "Error 500"}
+    test "Always returns payload body for 5xx" do
+      assert Payload.body(:payload, 500) == {:ok, ~s({"hello":"world"})}
     end
 
-    test "Always return 'Not Found' for 404s" do
-      assert Payload.body(:payload, 404) == {:ok, "Not found"}
+    test "Always returns payload body for 404s" do
+      assert Payload.body(:payload, 404) == {:ok, ~s({"hello":"world"})}
     end
 
     test "Suggests to add a recipe for 406" do


### PR DESCRIPTION
We don't want to overwrite the provided response body when a recipe returns anything other than a 200.