### PR TITLE
fix .formatter.exs and formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,7 +3,7 @@
   inputs: [
     "{mix,.formatter}.exs",
     "{config,test}/**/*.{ex,exs}",
-    "lib/{belfrage, belfrage_web}/**/*.{ex,exs}"
+    "lib/**/*.{ex,exs}"
   ],
-  line_length: 120
+  line_length: 180
 ]

--- a/lib/origin_simulator/counter.ex
+++ b/lib/origin_simulator/counter.ex
@@ -19,7 +19,6 @@ defmodule OriginSimulator.Counter do
 
   def increment(status_code) do
     Agent.update(__MODULE__, fn state ->
-
       state
       |> increment_key(:total_requests)
       |> increment_key(status_code)
@@ -27,10 +26,11 @@ defmodule OriginSimulator.Counter do
   end
 
   defp increment_key(state, key) do
-    {_, state} = Map.get_and_update(state, key, fn
-      nil -> {nil, 1}
-      current_value -> {current_value, current_value + 1}
-    end)
+    {_, state} =
+      Map.get_and_update(state, key, fn
+        nil -> {nil, 1}
+        current_value -> {current_value, current_value + 1}
+      end)
 
     state
   end

--- a/lib/origin_simulator/http_client.ex
+++ b/lib/origin_simulator/http_client.ex
@@ -1,16 +1,17 @@
 defmodule OriginSimulator.HTTPClient do
-  def get(endpoint, headers \\ %{})  
-  
+  def get(endpoint, headers \\ %{})
+
   def get(endpoint, %{"content-encoding" => "gzip"} = headers) do
-    new_headers = headers
-    |> Map.delete("content-encoding")
-    |> Map.put("accept-encoding", "gzip")
+    new_headers =
+      headers
+      |> Map.delete("content-encoding")
+      |> Map.put("accept-encoding", "gzip")
 
     get(endpoint, new_headers)
   end
 
   def get(endpoint, headers) do
     options = [recv_timeout: 3000]
-    HTTPoison.get(endpoint, headers |> Map.to_list, options)
+    HTTPoison.get(endpoint, headers |> Map.to_list(), options)
   end
 end

--- a/lib/origin_simulator/plug_response_counter.ex
+++ b/lib/origin_simulator/plug_response_counter.ex
@@ -5,7 +5,6 @@ defmodule OriginSimulator.PlugResponseCounter do
   def init(opts), do: opts
 
   def call(conn, _opts) do
-
     register_before_send(conn, fn conn ->
       OriginSimulator.Counter.increment(conn.status)
       conn

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -17,6 +17,7 @@ defmodule OriginSimulator.Supervisor do
       strategy: :one_for_all,
       max_restarts: 30
     ]
+
     Supervisor.init(children, opts)
   end
 end


### PR DESCRIPTION
Fix `.formatter.exs` input setting so that it catches and formats all source files in `lib/` directory.