### PR TITLE
random content range recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,24 @@ In this example we are requiring a continuous successful response with no simula
 
 ```json
 {
+    "route": "/*",
     "random_content": "428kb",
+    "stages": [
+        {
+            "at": 0,
+            "latency": 0,
+            "status": 200
+        }
+    ]
+}
+```
+
+To simulate serving payloads of different sizes, a random content range recipe can be used. For example, the example below enables OriginSimulator to serve payloads of random and varying sizes within a range of 300kb and 400kb. 
+
+```json
+{
+    "route": "/*",
+    "random_content": "300kb..400kb",
     "stages": [
         {
             "at": 0,

--- a/examples/permanent_200_random_content_range_gzip.json
+++ b/examples/permanent_200_random_content_range_gzip.json
@@ -1,0 +1,16 @@
+[
+  {
+    "stages": [
+      {
+        "status": 200,
+        "latency": 0,
+        "at": 0
+      }
+    ],
+    "route": "/*",
+    "random_content": "300kb..400kb",
+    "headers": {
+      "content-encoding": "gzip"
+    }
+  }
+]

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -23,11 +23,11 @@ defmodule OriginSimulator do
   def admin_domain(), do: Application.get_env(:origin_simulator, :admin_domain)
 
   defp serve_payload(conn, route) do
-    {status, latency} = Simulation.state(:simulation, route)
+    {status, latency, payload_id} = Simulation.state(:simulation, route)
 
     sleep(latency)
 
-    {:ok, body} = Payload.body(:payload, status, conn.request_path, route)
+    {:ok, body} = Payload.body(:payload, status, conn.request_path, payload_id)
 
     recipe = Simulation.recipe(:simulation, route)
 

--- a/lib/origin_simulator/flakiness.ex
+++ b/lib/origin_simulator/flakiness.ex
@@ -1,0 +1,77 @@
+defmodule OriginSimulator.Flakiness do
+  @moduledoc """
+  A server that introduces latency, payload and status flakiness
+  during simulation.
+  """
+  use GenServer
+  alias OriginSimulator.{Flakiness, Payload}
+
+  @default_interval 1000
+  @simulation_server :simulation
+
+  defstruct payload: [], status: [], route: "/*", interval: nil
+
+  @type t :: %__MODULE__{
+          payload: [binary()],
+          status: [integer()],
+          route: binary,
+          interval: integer()
+        }
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: :flakiness)
+  end
+
+  def new(), do: %Flakiness{}
+  def new(payload_series, route), do: %Flakiness{payload: payload_series, route: route}
+
+  def start(%{random_content: value}, route) do
+    String.split(value, "..")
+    |> Payload.random_payload_series()
+    |> Flakiness.new(route)
+    |> Map.put(:interval, @default_interval)
+    |> set()
+
+    start()
+  end
+
+  def set(flakiness), do: GenServer.call(:flakiness, {:set, flakiness})
+  def state(), do: GenServer.call(:flakiness, :state)
+  def start(), do: GenServer.call(:flakiness, :start)
+
+  # TODO
+  # def stop()
+
+  # Callbacks 
+
+  @impl true
+  def init(_) do
+    {:ok, new()}
+  end
+
+  @impl true
+  def handle_call(:state, _from, flakiness) do
+    {:reply, flakiness, flakiness}
+  end
+
+  @impl true
+  def handle_call(:start, _from, flakiness) do
+    send(self(), :flaky)
+    {:reply, :ok, flakiness}
+  end
+
+  @impl true
+  def handle_call({:set, new_flakiness}, _from, _flakiness) do
+    {:reply, :ok, new_flakiness}
+  end
+
+  @impl true
+  def handle_info(:flaky, flakiness) do
+    send(
+      @simulation_server,
+      {:update, {flakiness.route, flakiness.payload |> Enum.random()}}
+    )
+
+    {:noreply, flakiness}
+  end
+end

--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -84,6 +84,8 @@ defmodule OriginSimulator.Payload do
     min_integer = Regex.replace(@unit_regex, min, "") |> String.to_integer()
     max_integer = Regex.replace(@unit_regex, max, "") |> String.to_integer()
 
+    :ets.insert(:payload, {route, Body.randomise(max, recipe.headers)})
+
     min_integer..max_integer
     |> Enum.take_every(@range_step_size)
     |> Enum.filter(&(&1 != 0))

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,6 +1,7 @@
 defmodule OriginSimulator.Recipe do
   defstruct origin: nil, body: nil, random_content: nil, headers: %{}, stages: [], route: "/*"
 
+  # TODO: missing stage stages, type spec for 'stage'
   @type t :: %__MODULE__{
           origin: String.t(),
           body: String.t(),

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -112,8 +112,6 @@ defmodule OriginSimulator.Simulation do
     route = new_recipe.route
     simulation = get(state[route])
 
-    if auto_flakiness?(new_recipe), do: Flakiness.start(new_recipe, route)
-
     Enum.map(new_recipe.stages, fn item ->
       Process.send_after(
         self(),
@@ -121,6 +119,8 @@ defmodule OriginSimulator.Simulation do
         Duration.parse(item["at"])
       )
     end)
+
+    if auto_flakiness?(new_recipe), do: Flakiness.start(new_recipe, route)
 
     {:reply, :ok, Map.put(state, route, %{simulation | recipe: new_recipe})}
   end

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -1,13 +1,25 @@
 defmodule OriginSimulator.Simulation do
   use GenServer
 
-  alias OriginSimulator.{Recipe, Payload, Duration}
+  alias OriginSimulator.{Recipe, Payload, Duration, Simulation}
+
+  defstruct latency: 0, payload_id: nil, recipe: nil, status: 406
+
+  @type recipe :: OriginSimulator.Recipe.t()
+  @type t :: %__MODULE__{
+          latency: integer(),
+          payload_id: binary(),
+          recipe: recipe,
+          status: integer()
+        }
 
   ## Client API
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: :simulation)
   end
+
+  def new(), do: %Simulation{}
 
   def state(server) do
     GenServer.call(server, :state)
@@ -54,7 +66,7 @@ defmodule OriginSimulator.Simulation do
 
   @impl true
   def init(_) do
-    {:ok, %{Recipe.default_route() => default_simulation()}}
+    {:ok, %{Recipe.default_route() => new()}}
   end
 
   @impl true
@@ -115,10 +127,8 @@ defmodule OriginSimulator.Simulation do
     {:noreply, Map.put(state, route, %{state[route] | status: status, latency: latency})}
   end
 
-  defp get(nil), do: default_simulation()
+  defp get(nil), do: new()
   defp get(current_state), do: current_state
-
-  defp default_simulation(), do: %{recipe: nil, status: 406, latency: 0}
 
   defp match_route(state, nil, route) do
     Map.keys(state)

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -76,7 +76,7 @@ defmodule OriginSimulator.Simulation do
 
   @impl true
   def handle_call({:state, route}, _from, state) do
-    {:reply, {state[route].status, state[route].latency}, state}
+    {:reply, {state[route].status, state[route].latency, state[route].payload_id}, state}
   end
 
   @impl true
@@ -106,7 +106,7 @@ defmodule OriginSimulator.Simulation do
     Enum.map(new_recipe.stages, fn item ->
       Process.send_after(
         self(),
-        {:update, route, item["status"], Duration.parse(item["latency"])},
+        {:update, route, item["status"], Duration.parse(item["latency"]), route},
         Duration.parse(item["at"])
       )
     end)
@@ -123,8 +123,8 @@ defmodule OriginSimulator.Simulation do
   def handle_call(:route, _from, state), do: {:reply, state |> Map.keys(), state}
 
   @impl true
-  def handle_info({:update, route, status, latency}, state) do
-    {:noreply, Map.put(state, route, %{state[route] | status: status, latency: latency})}
+  def handle_info({:update, route, status, latency, payload_id}, state) do
+    {:noreply, Map.put(state, route, %{state[route] | status: status, latency: latency, payload_id: payload_id})}
   end
 
   defp get(nil), do: new()

--- a/lib/origin_simulator/simulation.ex
+++ b/lib/origin_simulator/simulation.ex
@@ -76,12 +76,21 @@ defmodule OriginSimulator.Simulation do
 
   @impl true
   def handle_call({:state, route}, _from, state) do
-    {:reply, {state[route].status, state[route].latency, state[route].payload_id}, state}
+    case state[route] do
+      %{status: status, latency: latency, payload_id: payload_id} ->
+        {:reply, {status, latency, payload_id}, state}
+
+      nil ->
+        {:reply, {406, 0, nil}, state}
+    end
   end
 
   @impl true
   def handle_call({:recipe, route}, _from, state) do
-    {:reply, state[route].recipe, state}
+    case state[route] do
+      %{recipe: recipe} -> {:reply, recipe, state}
+      nil -> {:reply, nil, state}
+    end
   end
 
   # retrieve all recipes

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -10,7 +10,8 @@ defmodule OriginSimulator.Supervisor do
     children = [
       OriginSimulator.Simulation,
       OriginSimulator.Payload,
-      OriginSimulator.Counter
+      OriginSimulator.Counter,
+      OriginSimulator.Flakiness
     ]
 
     opts = [

--- a/test/fixtures/recipes.exs
+++ b/test/fixtures/recipes.exs
@@ -27,11 +27,12 @@ defmodule Fixtures.Recipes do
     }
   end
 
-  def random_content_recipe(size \\ "50kb", headers \\ %{}) do
+  def random_content_recipe(size \\ "50kb", headers \\ %{}, route \\ "/*") do
     %Recipe{
       random_content: size,
       stages: [%{"at" => 0, "status" => 200, "latency" => 0}],
-      headers: headers
+      headers: headers,
+      route: route
     }
   end
 

--- a/test/origin_simulator/flakiness_test.exs
+++ b/test/origin_simulator/flakiness_test.exs
@@ -46,4 +46,15 @@ defmodule OriginSimulator.FlakinessTest do
              route: "/route_for_random_payloads"
            }
   end
+
+  test "current flakiness payload is within the intended random range" do
+    recipe = random_content_recipe("50kb..100kb", %{"content-encoding" => "gzip"}, "/route_for_random_payloads")
+
+    Simulation.add_recipe(@simulation_server, recipe)
+    Process.sleep(50)
+
+    {_status, _latency, {_route, payload}} = Simulation.state(@simulation_server, "/route_for_random_payloads")
+
+    assert payload in Flakiness.state().payload
+  end
 end

--- a/test/origin_simulator/flakiness_test.exs
+++ b/test/origin_simulator/flakiness_test.exs
@@ -10,7 +10,7 @@ defmodule OriginSimulator.FlakinessTest do
     assert Flakiness.new() == %Flakiness{interval: nil, payload: [], route: "/*", status: []}
   end
 
-  test "new/2 returns Flakiness struct with random payload series and route" do
+  test "new/2 returns a Flakiness struct for random payload series and route" do
     flakiness = Flakiness.new([150, 155, 160], "/an_origin_route")
 
     assert flakiness.payload == [150, 155, 160]

--- a/test/origin_simulator/flakiness_test.exs
+++ b/test/origin_simulator/flakiness_test.exs
@@ -1,0 +1,49 @@
+defmodule OriginSimulator.FlakinessTest do
+  use ExUnit.Case, async: true
+  import Fixtures.Recipes
+  alias OriginSimulator.{Flakiness, Simulation}
+
+  @default_interval 1000
+  @simulation_server :simulation
+
+  test "new/0 returns a new Flakiness struct" do
+    assert Flakiness.new() == %Flakiness{interval: nil, payload: [], route: "/*", status: []}
+  end
+
+  test "new/2 returns Flakiness struct with random payload series and route" do
+    flakiness = Flakiness.new([150, 155, 160], "/an_origin_route")
+
+    assert flakiness.payload == [150, 155, 160]
+    assert flakiness.route == "/an_origin_route"
+  end
+
+  test "state/0 returns the current flakiness state" do
+    Flakiness.new([150, 155, 160], "/an_origin_route")
+    |> Flakiness.set()
+
+    assert Flakiness.state() == %Flakiness{payload: [150, 155, 160], route: "/an_origin_route"}
+  end
+
+  test "set/1 flakiness" do
+    previous_flakiness = Flakiness.state()
+    new_flakiness = Flakiness.new([500, 505, 510], "/route_a")
+
+    Flakiness.set(new_flakiness)
+
+    refute Flakiness.state() == previous_flakiness
+    assert Flakiness.state() == %Flakiness{payload: [500, 505, 510], route: "/route_a"}
+  end
+
+  test "start/2 flakiness for a route" do
+    recipe = random_content_recipe("10kb..50kb", %{"content-encoding" => "gzip"}, "/route_for_random_payloads")
+
+    Simulation.add_recipe(@simulation_server, recipe)
+    Process.sleep(5)
+
+    assert Flakiness.state() == %Flakiness{
+             interval: @default_interval,
+             payload: [10, 15, 20, 25, 30, 35, 40, 45, 50],
+             route: "/route_for_random_payloads"
+           }
+  end
+end

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -5,7 +5,7 @@ defmodule OriginSimulator.PayloadTest do
 
   alias OriginSimulator.Payload
 
-  @range_step_size OriginSimulator.Payload.range_step_size()
+  @random_payload_step_size OriginSimulator.Payload.random_payload_step_size()
 
   # TODO: additional tests for fetching and storing multi-origin / source content in ETS
   describe "with origin" do
@@ -74,7 +74,7 @@ defmodule OriginSimulator.PayloadTest do
       Payload.fetch(:payload, random_content_recipe("0kb..100kb", %{"content-encoding" => "gzip"}))
 
       # currently with fixed 20kb step sizes
-      for size <- Enum.take_every(20..100, @range_step_size) do
+      for size <- Enum.take_every(20..100, @random_payload_step_size) do
         {:ok, gzip_content} = Payload.body(:payload, 200, "/*", {"/*", size})
         assert gzip_content |> :zlib.gunzip() |> String.length() == size * 1024
       end

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -16,12 +16,20 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status, latency, payload_id for a route", %{route: route} do
+    test "state/2 returns a tuple with http status, latency, payload_id for a route", %{route: route} do
       assert Simulation.state(:simulation, route) == {200, 1000, route}
     end
 
-    test "recipe() returns the loaded recipe for a route", %{recipe: recipe, route: route} do
+    test "state/2 does not crash GenServer and returns default tuple for non existing routes" do
+      assert Simulation.state(:simulation, "/non_existing") == {406, 0, nil}
+    end
+
+    test "recipe/2 returns the loaded recipe for a route", %{recipe: recipe, route: route} do
       assert Simulation.recipe(:simulation, route) == recipe
+    end
+
+    test "recipe/2 does not crash GenServer and returns nil for non existing routes" do
+      assert Simulation.recipe(:simulation, "/non_existing") == nil
     end
 
     test "route/2 returns matching route", %{recipe: recipe, route: route} do
@@ -73,11 +81,11 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
+    test "state/2 returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
       assert Simulation.state(:simulation, route) == {200, 1000..1200, route}
     end
 
-    test "recipe() returns the loaded recipe", %{recipe: recipe, route: route} do
+    test "recipe/2 returns the loaded recipe", %{recipe: recipe, route: route} do
       assert Simulation.recipe(:simulation, route) == recipe
     end
   end
@@ -96,13 +104,13 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
+    test "state/2 returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
       assert Simulation.state(:simulation, route) == {200, 0, route}
       Process.sleep(80)
       assert Simulation.state(:simulation, route) == {503, 1000, route}
     end
 
-    test "recipe() returns the loaded recipe", %{recipe: recipe, route: route} do
+    test "recipe/2 returns the loaded recipe", %{recipe: recipe, route: route} do
       assert Simulation.recipe(:simulation, route) == recipe
     end
   end
@@ -113,15 +121,15 @@ defmodule OriginSimulator.SimulationTest do
       Process.sleep(5)
     end
 
-    test "state() returns a tuple with default values" do
+    test "state/2 returns a tuple with default values" do
       assert Simulation.state(:simulation, Recipe.default_route()) == {406, 0, nil}
     end
 
-    test "recipe() returns an empty list" do
+    test "recipe/1 returns an empty list" do
       assert Simulation.recipe(:simulation) == []
     end
 
-    test "route() returns default route" do
+    test "route/2 returns default route" do
       assert Simulation.route(:simulation, "/random_path") == "/*"
     end
   end

--- a/test/origin_simulator/simulation_test.exs
+++ b/test/origin_simulator/simulation_test.exs
@@ -16,8 +16,8 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status and latency in ms for a route", %{route: route} do
-      assert Simulation.state(:simulation, route) == {200, 1000}
+    test "state() returns a tuple with http status, latency, payload_id for a route", %{route: route} do
+      assert Simulation.state(:simulation, route) == {200, 1000, route}
     end
 
     test "recipe() returns the loaded recipe for a route", %{recipe: recipe, route: route} do
@@ -73,8 +73,8 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status and latency in ms", %{route: route} do
-      assert Simulation.state(:simulation, route) == {200, 1000..1200}
+    test "state() returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
+      assert Simulation.state(:simulation, route) == {200, 1000..1200, route}
     end
 
     test "recipe() returns the loaded recipe", %{recipe: recipe, route: route} do
@@ -96,10 +96,10 @@ defmodule OriginSimulator.SimulationTest do
       {:ok, recipe: recipe, route: recipe.route}
     end
 
-    test "state() returns a tuple with http status and latency in ms", %{route: route} do
-      assert Simulation.state(:simulation, route) == {200, 0}
+    test "state() returns a tuple with http status, latency in ms, payload id (route)", %{route: route} do
+      assert Simulation.state(:simulation, route) == {200, 0, route}
       Process.sleep(80)
-      assert Simulation.state(:simulation, route) == {503, 1000}
+      assert Simulation.state(:simulation, route) == {503, 1000, route}
     end
 
     test "recipe() returns the loaded recipe", %{recipe: recipe, route: route} do
@@ -114,7 +114,7 @@ defmodule OriginSimulator.SimulationTest do
     end
 
     test "state() returns a tuple with default values" do
-      assert Simulation.state(:simulation, Recipe.default_route()) == {406, 0}
+      assert Simulation.state(:simulation, Recipe.default_route()) == {406, 0, nil}
     end
 
     test "recipe() returns an empty list" do


### PR DESCRIPTION
This PR introduces a recipe type that enables OriginSimulator to service response payloads of random and varying sizes within a given range, e.g. between 300kb and 400kb in the recipe below.

It also adds a Simulation data struct, and a separate GenServer that injects flakiness (varying response payload sizes) into simulation without incurring performance cost on the main simulation server.

```json
{
    "route": "/*",
    "random_content": "300kb..400kb",
    "stages": [
        { "at": 0, "status": 200, "latency": 0}
    ],
    "headers": {
      "content-encoding": "gzip"
    }
}
```