### PR TITLE
fix response counter bug

### DIFF
--- a/lib/origin_simulator/counter.ex
+++ b/lib/origin_simulator/counter.ex
@@ -17,6 +17,9 @@ defmodule OriginSimulator.Counter do
     end)
   end
 
+  def increment("/_admin/" <> _path, _status_code), do: :ok
+  def increment(_path, status_code), do: increment(status_code)
+
   def increment(status_code) do
     Agent.update(__MODULE__, fn state ->
       state

--- a/lib/origin_simulator/plug/response_counter.ex
+++ b/lib/origin_simulator/plug/response_counter.ex
@@ -6,7 +6,7 @@ defmodule OriginSimulator.Plug.ResponseCounter do
 
   def call(conn, _opts) do
     register_before_send(conn, fn conn ->
-      OriginSimulator.Counter.increment(conn.status)
+      OriginSimulator.Counter.increment(conn.request_path, conn.status)
       conn
     end)
   end

--- a/test/origin_simulator/admin_router_test.exs
+++ b/test/origin_simulator/admin_router_test.exs
@@ -41,6 +41,13 @@ defmodule OriginSimulator.AdminRouterTest do
       |> assert_status_body(406, recipe_not_set("/another_domain/routes"))
       |> assert_resp_header({"content-type", ["text/html; charset=utf-8"]})
     end
+
+    test "will not increment response counter" do
+      current_count = OriginSimulator.Counter.value().total_requests
+      conn(:get, "/#{admin_domain()}/routes") |> OriginSimulator.call([])
+
+      assert OriginSimulator.Counter.value().total_requests == current_count
+    end
   end
 
   describe "GET /#{admin_domain()}/routes_status" do

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -138,6 +138,17 @@ defmodule OriginSimulatorTest do
       assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
       assert String.length(conn.resp_body |> :zlib.gunzip()) == 50 * 1024
     end
+
+    test "will increment response counter" do
+      payload = origin_recipe() |> Poison.encode!()
+      conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
+      Process.sleep(20)
+
+      current_count = OriginSimulator.Counter.value().total_requests
+      conn(:get, "/") |> OriginSimulator.call([])
+
+      assert OriginSimulator.Counter.value().total_requests == current_count + 1
+    end
   end
 
   describe "POST / when a recipe is set" do


### PR DESCRIPTION
This small PR fixes the response counter. It no longer counts admin (`/_admin` pages) traffics.