### PR TITLE
documentation and typespec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.0 (2020-10-02)
+
+* Initial release

--- a/lib/mix/upload_recipe.ex
+++ b/lib/mix/upload_recipe.ex
@@ -1,6 +1,19 @@
 defmodule Mix.Tasks.UploadRecipe do
+  @moduledoc """
+  A mix task for uploading JSON recipes in the `examples` directory to OriginSimulator.
+
+  ```
+  # upload `examples/demo.json` to OriginSimulator running locally (http://localhost:8080).
+  mix upload_recipe demo
+
+  # upload `examples/demo.json to OriginSimulator on a specific host.
+  mix upload_recipe "http://origin-simulator.com" demo
+  ```
+  """
+
   use Mix.Task
 
+  @spec run(list()) :: {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t()} | {:error, HTTPoison.Error.t()}
   def run([host, recipe]) do
     {:ok, _started} = Application.ensure_all_started(:httpoison)
 

--- a/lib/origin_simulator.ex
+++ b/lib/origin_simulator.ex
@@ -1,4 +1,8 @@
 defmodule OriginSimulator do
+  @moduledoc """
+  Main router for handling and responding to OriginSimulator requests.
+  """
+
   use Plug.Router
   alias OriginSimulator.{Payload, Simulation, Plug.ResponseCounter}
 
@@ -20,6 +24,7 @@ defmodule OriginSimulator do
     send_resp(conn, 404, "not found")
   end
 
+  @doc false
   def admin_domain(), do: Application.get_env(:origin_simulator, :admin_domain)
 
   defp serve_payload(conn, route) do
@@ -52,9 +57,11 @@ defmodule OriginSimulator do
   defp sleep(%Range{} = time), do: :timer.sleep(Enum.random(time))
   defp sleep(duration), do: :timer.sleep(duration)
 
+  @doc false
   def recipe_not_set(),
     do: "Recipe not set, please POST a recipe to /#{admin_domain()}/add_recipe"
 
+  @doc false
   def recipe_not_set(path) do
     "Recipe not set at #{path}, please POST a recipe for this route to /#{admin_domain()}/add_recipe"
   end

--- a/lib/origin_simulator/admin_router.ex
+++ b/lib/origin_simulator/admin_router.ex
@@ -1,4 +1,34 @@
 defmodule OriginSimulator.AdminRouter do
+  @moduledoc """
+  Router for handling and responding to admin requests.
+
+  #### Admin routes
+
+  * /_admin/status
+
+  Check if the simulator is running, return `ok!`
+
+  * /_admin/add_recipe
+
+  Post (POST) recipe: update or create new origins
+
+  * /_admin/current_recipe
+
+  List existing recipe for all origins and routes
+
+  * /_admin/restart
+
+  Reset the simulator: remove all recipes
+
+  * /_admin/routes
+
+  List all origins and routes
+
+  * /_admin/routes_status
+
+  List all origin and routes with the corresponding current status and latency values
+  """
+
   use Plug.Router
 
   alias OriginSimulator.{Recipe, Simulation, Counter}

--- a/lib/origin_simulator/body.ex
+++ b/lib/origin_simulator/body.ex
@@ -1,8 +1,35 @@
 defmodule OriginSimulator.Body do
+  @moduledoc """
+  Utilities for generating OriginSimulator recipe response payloads (body).
+  """
   @regex ~r"<<(.+?)>>"
 
   alias OriginSimulator.Size
 
+  @doc """
+  Parse a string value to include generated and compressed random payload if required.
+
+  OriginSimulator response payload can be defined in recipes. The payload
+  can also include random content specified with tags, e.g. <<10kb>>.
+
+  ```
+  iex> OriginSimulator.Body.parse("{\"payload\":\"test\"}")
+  "{\"payload\":\"test\"}"
+
+  # generate random content with <<100b>>
+  iex> OriginSimulator.Body.parse("{\"payload\":\"<<100b>>\"}")
+  "{\"payload\":\"iDS0MMNKT3QMmEiOPvjeIsEXB7cjGlGktCLCMta3D8ZleSHbcbUn1mNa470POxzDJAhJvP4L3cDhDvwBP5eQC8fGMo3DCgewZzBv\"}"
+  ```
+
+  Payload can be compressed with a `%{"content-encoding" => "gzip"}` header.
+  ```
+  iex> OriginSimulator.Body.parse("{\"payload\":\"<<100b>>\"}", %{"content-encoding" => "gzip"})
+  <<31, 139, 8, 0, 0, 0, 0, 0, 0, 19, 171, 86, 42, 72, 172, 204, 201, 79, 76, 81,
+    178, 82, 50, 8, 115, 214, 15, 169, 114, 245, 74, 244, 204, 205, 44, 54, 52,
+    174, 242, 170, 204, 244, 11, 171, 172, 50, 205, 201, 43, 54, ...>>
+  ```
+  """
+  @spec parse(binary(), map()) :: binary()
   def parse(str, headers \\ %{})
 
   def parse(str, %{"content-encoding" => "gzip"}) do
@@ -14,6 +41,18 @@ defmodule OriginSimulator.Body do
     Regex.replace(@regex, str, fn _whole, tag -> randomise(tag) end)
   end
 
+  @doc """
+  Generate and compress random payload.
+
+  ```
+  # generate 100kb random payload in gzip format
+  iex(1)> OriginSimulator.Body.randomise("100kb", %{"content-encoding" => "gzip"})
+  <<31, 139, 8, 0, 0, 0, 0, 0, 0, 19, 20, 154, 69, 178, 227, 64, 16, 5, 15, 228,
+    133, 152, 150, 98, 102, 214, 78, 204, 204, 58, 253, 252, 89, 59, 28, 182, 186,
+    171, 222, 203, 116, 88, 158, 88, 201, 207, 21, 14, 52, 48, ...>>
+  ```
+  """
+  @spec randomise(binary(), map()) :: binary()
   def randomise(tag, headers \\ %{})
   def randomise(tag, %{"content-encoding" => "gzip"}), do: randomise(tag, %{}) |> :zlib.gzip()
 

--- a/lib/origin_simulator/counter.ex
+++ b/lib/origin_simulator/counter.ex
@@ -1,4 +1,6 @@
 defmodule OriginSimulator.Counter do
+  @moduledoc false
+
   use Agent
 
   @initial_state %{total_requests: 0}

--- a/lib/origin_simulator/duration.ex
+++ b/lib/origin_simulator/duration.ex
@@ -1,4 +1,5 @@
 defmodule OriginSimulator.Duration do
+  @moduledoc false
   def parse(0), do: 0
 
   def parse(time) when is_integer(time) do

--- a/lib/origin_simulator/http/client.ex
+++ b/lib/origin_simulator/http/client.ex
@@ -1,4 +1,5 @@
 defmodule OriginSimulator.HTTP.Client do
+  @moduledoc false
   def get(endpoint, headers \\ %{})
 
   def get(endpoint, %{"content-encoding" => "gzip"} = headers) do

--- a/lib/origin_simulator/http/mock_client.ex
+++ b/lib/origin_simulator/http/mock_client.ex
@@ -1,4 +1,5 @@
 defmodule OriginSimulator.HTTP.MockClient do
+  @moduledoc false
   def get(_endpoint, headers \\ %{})
   def get(_endpoint, %{"content-type" => "application/json"}), do: {:ok, %HTTPoison.Response{body: "{\"hello\":\"world\"}"}}
   def get(_endpoint, %{"content-encoding" => "gzip"}), do: {:ok, %HTTPoison.Response{body: :zlib.gzip("some content from origin")}}

--- a/lib/origin_simulator/plug/response_counter.ex
+++ b/lib/origin_simulator/plug/response_counter.ex
@@ -1,4 +1,6 @@
 defmodule OriginSimulator.Plug.ResponseCounter do
+  @moduledoc false
+
   @behaviour Plug
   import Plug.Conn, only: [register_before_send: 2]
 

--- a/lib/origin_simulator/recipe.ex
+++ b/lib/origin_simulator/recipe.ex
@@ -1,4 +1,13 @@
 defmodule OriginSimulator.Recipe do
+  @moduledoc """
+  Data struct and functions underpinning OriginSimulator recipes.
+
+  A recipe defines the different stages of a [simulation scenario](readme.html#scenarios).
+  It is a JSON that can be uploaded to OriginSimulator via HTTP POST. The recipe is
+  represented internally as a struct. This module also provides a function to parse
+  JSON recipe into struct.
+  """
+
   defstruct origin: nil, body: nil, random_content: nil, headers: %{}, stages: [], route: "/*"
 
   @type t :: %__MODULE__{
@@ -9,11 +18,15 @@ defmodule OriginSimulator.Recipe do
           route: String.t()
         }
 
+  @doc """
+  Parse a JSON recipe into `t:OriginSimulator.Recipe.t/0` data struct.
+  """
   # TODO: parameters don't make sense, need fixing
   @spec parse({:ok, binary(), any()}) :: binary()
   def parse({:ok, "[" <> body, _conn}), do: Poison.decode!("[" <> body, as: [%__MODULE__{}])
   def parse({:ok, body, _conn}), do: Poison.decode!(body, as: %__MODULE__{})
 
+  @doc false
   @spec default_route() :: binary()
   def default_route(), do: %__MODULE__{}.route
 end

--- a/lib/origin_simulator/size.ex
+++ b/lib/origin_simulator/size.ex
@@ -1,4 +1,5 @@
 defmodule OriginSimulator.Size do
+  @moduledoc false
   def parse(size) when is_binary(size) do
     Integer.parse(size) |> parse()
   end

--- a/lib/origin_simulator/supervisor.ex
+++ b/lib/origin_simulator/supervisor.ex
@@ -1,4 +1,8 @@
 defmodule OriginSimulator.Supervisor do
+  @moduledoc """
+  `Supervisor` of OriginSimulator server processes.
+  """
+
   use Supervisor
 
   def start_link(init_arg) do


### PR DESCRIPTION
Provide documentation and typespecs in all modules to enable publication to Hex and HexDocs.

To generate and view documentation locally run:

```ex
mix docs
```