### PR TITLE
MORPH-2416: Publish RPMs to the origin-simulator-fabl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ library 'BBCNews'
 
 def cosmosServices = [
     'origin-simulator',
-    'origin-simulator-data-pres'
+    'origin-simulator-data-pres',
+    'origin-simulator-fabl'
 ]
 
 node {


### PR DESCRIPTION
# Problem
We (the FABL team) want to spin up our own Origin Simulator service so we can load test FABL as and when we need to without having to coordinate with other teams that may want to use Origin Simulator. However, we want to ensure we are always using latest version of the Origin Simulator RPM.

# Solution
Publish the Origin Simulator RPMs to a new Cosmos component called `origin-simulator-fabl`, in addition to the usual places.