### PR TITLE
RESFRAME-4211 - Set nofile in .service file instead of nofile.conf

### DIFF
--- a/SOURCES/nofile.conf
+++ b/SOURCES/nofile.conf
@@ -1,2 +1,0 @@
-*    soft    nofile 128_000
-*    hard    nofile 128_000

--- a/SOURCES/origin_simulator.service
+++ b/SOURCES/origin_simulator.service
@@ -4,6 +4,7 @@ After=network.target network-online.target
 [Service]
 Environment=HOME=/home/component
 Environment=PORT=8080
+LimitNOFILE=128000
 User=component
 Group=component
 WorkingDirectory=/home/component/origin_simulator

--- a/origin-simulator.spec
+++ b/origin-simulator.spec
@@ -46,4 +46,3 @@ systemctl enable origin_simulator
 /home/component
 /usr/lib/systemd/system/origin_simulator.service
 /etc/sysctl.d/performance.conf
-/etc/security/limits.d/nofile.conf

--- a/origin-simulator.spec
+++ b/origin-simulator.spec
@@ -9,8 +9,7 @@ Packager: BBC News Frameworks and Tools
 
 Source0: origin_simulator.tar.gz
 Source1: origin_simulator.service
-Source2: nofile.conf
-Source3: performance.conf
+Source2: performance.conf
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: x86_64
@@ -37,8 +36,7 @@ mkdir -p %{buildroot}/home/component/origin_simulator
 tar -C %{buildroot}/home/component/origin_simulator -xzf %{SOURCE0}
 mkdir -p %{buildroot}/usr/lib/systemd/system
 cp %{SOURCE1} %{buildroot}/usr/lib/systemd/system/origin_simulator.service
-cp %{SOURCE2} %{buildroot}/etc/security/limits.d/nofile.conf
-cp %{SOURCE3} %{buildroot}/etc/sysctl.d/performance.conf
+cp %{SOURCE2} %{buildroot}/etc/sysctl.d/performance.conf
 
 %post
 systemctl enable origin_simulator


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/RESFRAME-4211

When checking if the value for nofile had been set I found it was not being set by the nofile.conf file, as you can see here in the cosmos release 59.multi.status.recipe (last OS release) which has the nofile value in the nofile.conf set to 32768, the default of 1024/4096 is used:
<img width="550" alt="Screenshot 2021-04-19 at 08 51 03" src="https://user-images.githubusercontent.com/24276806/115200775-7b856d80-a0ec-11eb-934e-a57a1da0961d.png">

This has now been changed to this:
<img width="550" alt="Screenshot 2021-04-19 at 08 42 34" src="https://user-images.githubusercontent.com/24276806/115200858-948e1e80-a0ec-11eb-8bb7-6b472e9e3102.png">
Which uses the origin_simulator.service file similar to what we do in belfrage