### PR TITLE
Support 304 not modified responses

### DIFF
--- a/lib/origin_simulator/payload.ex
+++ b/lib/origin_simulator/payload.ex
@@ -27,6 +27,7 @@ defmodule OriginSimulator.Payload do
   def body(_server, status, path \\ Recipe.default_route(), route \\ Recipe.default_route()) do
     case {status, path} do
       {200, _} -> cache_lookup(route)
+      {304, _} -> {:ok, ""}
       {404, _} -> {:ok, "Not found"}
       {406, "/*"} -> {:ok, OriginSimulator.recipe_not_set()}
       {406, _} -> {:ok, OriginSimulator.recipe_not_set(path)}

--- a/test/origin_simulator/origin_simulator_test.exs
+++ b/test/origin_simulator/origin_simulator_test.exs
@@ -149,6 +149,24 @@ defmodule OriginSimulatorTest do
 
       assert OriginSimulator.Counter.value().total_requests == current_count + 1
     end
+
+    test "will return an empty body with 304 status" do
+      recipe =
+        recipe(
+          body: "",
+          stages: [%{"at" => 0, "status" => 304, "latency" => 0}]
+        )
+
+      payload = recipe |> Poison.encode!()
+
+      conn(:post, "/#{admin_domain()}/add_recipe", payload) |> OriginSimulator.call([])
+      Process.sleep(20)
+
+      conn(:get, "/")
+      |> OriginSimulator.call([])
+      |> assert_status_body(304, "")
+      |> assert_resp_header({"content-type", ["text/html; charset=utf-8"]})
+    end
   end
 
   describe "POST / when a recipe is set" do

--- a/test/origin_simulator/payload_test.exs
+++ b/test/origin_simulator/payload_test.exs
@@ -50,6 +50,12 @@ defmodule OriginSimulator.PayloadTest do
     end
   end
 
+  describe "without content for not modified" do
+    test "returns an empty body" do
+      assert Payload.body(:payload, 304) == {:ok, ""}
+    end
+  end
+
   describe "recipe with gzip content-encoding header" do
     test "returns gzip body from origin" do
       Payload.fetch(:payload, origin_recipe(%{"content-encoding" => "gzip"}))


### PR DESCRIPTION
This adds support for a not modified response which has a 304 response status code and an empty body. This fixes the error:
```
origin_simulator: ** (exit) an exception was raised:
origin_simulator: ** (MatchError) no match of right hand side value: 9
```