### PR TITLE
Add `on-failure: ABORT` to each phase in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,10 +2,11 @@ version: 0.2
 
 phases:
   pre_build:
+    on-failure: ABORT
     commands:
       - certee-fetch
-
   build:
+    on-failure: ABORT
     commands:
        - mix deps.get
        - mix distillery.release
@@ -19,6 +20,7 @@ phases:
        - export COSMOS_VERSION=`cosmos-release generate-version origin-simulator`
        - rpmbuild -ba --define "cosmos_version ${COSMOS_VERSION}" origin-simulator.spec
   post_build:
+    on-failure: ABORT
     commands:
        - echo "Releasing 'RPMS/**/*.rpm' to origin-simulator"
        - cd $CODEBUILD_SRC_DIR


### PR DESCRIPTION
ISSUE: https://jira.dev.bbc.co.uk/browse/RESFRAME-5465

We want to stop the build as soon as there is a failure. We need to have `on-failure: ABORT` in each phase otherwise the build will continue, even if there's something wrong.