### PR TITLE
Add origin-simulator-fabl

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,4 +26,3 @@ phases:
        - cd $CODEBUILD_SRC_DIR
        - cosmos-release service 'origin-simulator' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm
        - cosmos-release service 'origin-simulator-fabl' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm
-       - cosmos-release service 'origin-simulator-data-pres' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,3 +25,5 @@ phases:
        - echo "Releasing 'RPMS/**/*.rpm' to origin-simulator"
        - cd $CODEBUILD_SRC_DIR
        - cosmos-release service 'origin-simulator' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm
+       - cosmos-release service 'origin-simulator-fabl' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm
+       - cosmos-release service 'origin-simulator-data-pres' --release-version=v /root/rpmbuild/RPMS/x86_64/*.x86_64.rpm


### PR DESCRIPTION
ISSUE: https://jira.dev.bbc.co.uk/browse/RESFRAME-5901
# Description
Added logic to `buildspec.yml` for `origin-simulator` project to push releases to `origin-simulator-fabl`.

## Tests
- [x] We can push to `origin-simulator-fabl`[here](https://cosmos.tools.bbc.co.uk/services/origin-simulator-fabl).